### PR TITLE
added st_transform.py for spatial temporal transformation of events m…

### DIFF
--- a/spike_data_augmentation/functional/st_transform.py
+++ b/spike_data_augmentation/functional/st_transform.py
@@ -1,12 +1,13 @@
 import numpy as np
 
 from .utils import guess_event_ordering_numpy
+from .time_skew import time_skew_numpy
 
 def st_transform(
     events,
-    ordering,
     spatial_transform,
     temporal_transform,
+    ordering = None,
     Roll = False,
     sensor_size=(346, 260)):
     """
@@ -28,15 +29,17 @@ def st_transform(
     Otherwise, events will be clipped at sensor boundaries.
     sensor_size - tuple which stipulates sensor size and used to determine tranform limits.
     Returns:
-    events - returns the input events with tranformed temporal and spatial location
+    tr_events - returns the input events with tranformed temporal and spatial location
     """
 
     if ordering is None:
         ordering = guess_event_ordering_numpy(events)
-        assert "x" and "y" in ordering
+        assert "x" and "y" and "t" and "p" in ordering
 
     x_index = ordering.find("x")
     y_index = ordering.find("y")
+    t_index = ordering.find("t")
+    p_index = ordering.find("p")
 
     number_events = events.shape[0]
 
@@ -48,25 +51,27 @@ def st_transform(
     events_spatial_transform_X = events_spatial_transform[x_index,:]
     events_spatial_transform_Y = events_spatial_transform[y_index,:]
 
-    outOfRange_eventsX_P = np.where(events_spatial_transform[x_index,:] >= sensor_size[1]) # Out Of Range coordinates based on imDim
+    outOfRange_eventsX_P = np.where(events_spatial_transform[x_index,:] >= sensor_size[0]) # Out Of Range coordinates based on imDim
     outOfRange_eventsX_N = np.where(events_spatial_transform[x_index,:] < 0)
-    outOfRange_eventsY_P = np.where(events_spatial_transform[y_index,:] >= sensor_size[0])
+    outOfRange_eventsY_P = np.where(events_spatial_transform[y_index,:] >= sensor_size[1])
     outOfRange_eventsY_N = np.where(events_spatial_transform[y_index,:] < 0)
 
     if Roll:
-        events_spatial_transform_X[outOfRange_eventsX_P] -= sensor_size[0] # Roll X right
-        events_spatial_transform_X[outOfRange_eventsX_N] += sensor_size[0] # Roll X left
-        events_spatial_transform_Y[outOfRange_eventsY_P] -= sensor_size[1] # Roll Y down
-        events_spatial_transform_Y[outOfRange_eventsY_N] += sensor_size[1] # Roll Y up
+        events_spatial_transform_X[outOfRange_eventsX_P] -= sensor_size[0]-1 # Roll X right
+        events_spatial_transform_X[outOfRange_eventsX_N] += sensor_size[0]-1 # Roll X left
+        events_spatial_transform_Y[outOfRange_eventsY_P] -= sensor_size[1]-1 # Roll Y down
+        events_spatial_transform_Y[outOfRange_eventsY_N] += sensor_size[1]-1 # Roll Y up
     else:
-        events_spatial_transform_X[outOfRange_eventsX_P] = sensor_size[0] # Clip X pos.
+        events_spatial_transform_X[outOfRange_eventsX_P] = sensor_size[0]-1 # Clip X pos.
         events_spatial_transform_X[outOfRange_eventsX_N] = 0 # Clip X neg.
-        events_spatial_transform_Y[outOfRange_eventsY_P] = sensor_size[1] # Clip Y pos.
+        events_spatial_transform_Y[outOfRange_eventsY_P] = sensor_size[1]-1 # Clip Y pos.
         events_spatial_transform_Y[outOfRange_eventsY_N] = 0 # Clip Y neg.
 
-    events[:,x_index] = events_spatial_transform_X.T
-    events[:,y_index] = events_spatial_transform_Y.T
+    tr_events = np.zeros((number_events,4))
+    tr_events[:,x_index] = events_spatial_transform_X.T
+    tr_events[:,y_index] = events_spatial_transform_Y.T
+    tr_events[:,t_index] = events[:,t_index]
+    tr_events[:,p_index] = events[:,p_index]
+    tr_events = time_skew_numpy(tr_events, ordering, temporal_transform[0], temporal_transform[1])
 
-    events = time_skew(events, ordering, temporal_transform[0], temporal_transform[1])
-
-    return events
+    return tr_events

--- a/test/numpy_test/test_functional.py
+++ b/test/numpy_test/test_functional.py
@@ -205,3 +205,20 @@ class TestFunctionalAPI(unittest.TestCase):
             images.shape[1] == 50 and images.shape[2] == 50,
             "Cropping needs to map the images into the new space",
         )
+
+    def testStTransform(self):
+        spatial_transform = np.array(((1, 0, 10), (0, 1, 10), (0, 0, 1)))
+        temporal_transform = np.array((2, 0))
+        events = F.st_transform(
+            self.random_xytp[0],
+            spatial_transform,
+            temporal_transform,
+            Roll=False,
+            sensor_size=self.random_xytp[2],
+            ordering=self.random_xytp[3]
+        )
+
+        self.assertTrue(
+            np.all(events[:, 0]) < self.random_xytp[2][0] and np.all(events[:, 1] < self.random_xytp[2][1]),
+            "Transformation does not map beyond sensor size",
+        )


### PR DESCRIPTION
added my function st_transform.py to the repo, it takes a 3x3 transform matrix along with a 1x2 time transform vector. In addition, the method allows the user to specify if they want the spatial coordinates to roll around the image dimensions when scaled, translated, etc. 