### PR TITLE
Limiting temporally and spatially jittered events

### DIFF
--- a/spike_data_augmentation/transforms.py
+++ b/spike_data_augmentation/transforms.py
@@ -99,10 +99,19 @@ class RefractoryPeriod(object):
 
 
 class SpatialJitter(object):
-    def __init__(self, variance_x=1, variance_y=1, sigma_x_y=0):
+    def __init__(
+        self,
+        variance_x=1,
+        variance_y=1,
+        sigma_x_y=0,
+        integer_coordinates=True,
+        clip_outliers=True,
+    ):
         self.variance_x = variance_x
         self.variance_y = variance_y
         self.sigma_x_y = sigma_x_y
+        self.integer_coordinates = integer_coordinates
+        self.clip_outliers = clip_outliers
 
     def __call__(self, events, sensor_size, ordering, images=None, multi_image=None):
         events = functional.spatial_jitter_numpy(
@@ -112,6 +121,8 @@ class SpatialJitter(object):
             self.variance_x,
             self.variance_y,
             self.sigma_x_y,
+            self.integer_coordinates,
+            self.clip_outliers,
         )
         return events, images
 
@@ -135,11 +146,15 @@ class SpatioTemporalTransform(object):
 
 
 class TimeJitter(object):
-    def __init__(self, variance=1):
+    def __init__(self, variance=1, integer_timestamps=False, clip_negative=True):
         self.variance = variance
+        self.integer_timestamps = integer_timestamps
+        self.clip_negative = clip_negative
 
     def __call__(self, events, sensor_size, ordering, images=None, multi_image=None):
-        events = functional.time_jitter_numpy(events, ordering, self.variance)
+        events = functional.time_jitter_numpy(
+            events, ordering, self.variance, self.integer_timestamps, self.clip_negative
+        )
         return events, images
 
 

--- a/test/numpy_test/test_functional.py
+++ b/test/numpy_test/test_functional.py
@@ -412,6 +412,8 @@ class TestFunctionalAPI(unittest.TestCase):
             variance_x=variance,
             variance_y=variance,
             sigma_x_y=0,
+            integer_coordinates=True,
+            clip_outliers=False,
         )
 
         self.assertTrue(len(events) == len(original_events))
@@ -442,6 +444,8 @@ class TestFunctionalAPI(unittest.TestCase):
             variance_x=variance,
             variance_y=variance,
             sigma_x_y=0,
+            integer_coordinates=True,
+            clip_outliers=False,
         )
 
         self.assertTrue(len(events) == len(original_events))
@@ -501,7 +505,11 @@ class TestFunctionalAPI(unittest.TestCase):
         original_events = self.random_xytp[0].copy()
         variance = max(self.random_xytp[0][:, 2]) / 10
         events = F.time_jitter_numpy(
-            self.random_xytp[0], ordering=self.random_xytp[3], variance=variance
+            self.random_xytp[0],
+            ordering=self.random_xytp[3],
+            variance=variance,
+            integer_timestamps=False,
+            clip_negative=False,
         )
 
         self.assertTrue(len(events) == len(original_events))
@@ -516,7 +524,11 @@ class TestFunctionalAPI(unittest.TestCase):
         original_events = self.random_txyp[0].copy()
         variance = max(self.random_txyp[0][:, 0]) / 10
         events = F.time_jitter_numpy(
-            self.random_txyp[0], ordering=self.random_txyp[3], variance=variance
+            self.random_txyp[0],
+            ordering=self.random_txyp[3],
+            variance=variance,
+            integer_timestamps=False,
+            clip_negative=False,
         )
 
         self.assertTrue(len(events) == len(original_events))

--- a/test/transforms/test_transforms.py
+++ b/test/transforms/test_transforms.py
@@ -14,7 +14,9 @@ class TestTransforms(unittest.TestCase):
         events = self.random_xytp[0].copy()
         images = None
         variance = max(self.random_xytp[0][:, 2]) / 10
-        transform = transforms.Compose([transforms.TimeJitter(variance=variance)])
+        transform = transforms.Compose(
+            [transforms.TimeJitter(variance=variance, clip_negative=False)]
+        )
         transform(
             events=events, sensor_size=self.random_xytp[2], ordering=self.random_xytp[3]
         )
@@ -42,7 +44,10 @@ class TestTransforms(unittest.TestCase):
             [
                 transforms.TimeReversal(flip_probability=flip_probability),
                 transforms.SpatialJitter(
-                    variance_x=variance_x, variance_y=variance_y, sigma_x_y=sigma_x_y
+                    variance_x=variance_x,
+                    variance_y=variance_y,
+                    sigma_x_y=sigma_x_y,
+                    clip_outliers=False,
                 ),
             ]
         )


### PR DESCRIPTION
limiting negative timestamps when using time jitter and coordinates outside the sensor size when using spatial jitter. At the moment I just set values to zero / maximum sensor size. Maybe it's better to drop those events completely?