### PR TITLE
fix obsolete call to MaskIsolated

### DIFF
--- a/tonic/utils.py
+++ b/tonic/utils.py
@@ -24,7 +24,7 @@ def plot_events(events, sensor_size, ordering, frame_time=25000, repeat=False):
 
     transform = transforms.Compose(
         [
-            transforms.MaskIsolated(time_filter=20000),
+            transforms.Denoise(time_filter=20000),
             transforms.ToRatecodedFrame(frame_time=frame_time, merge_polarities=True),
         ]
     )


### PR DESCRIPTION
`MaskIsolated` was  renamed to `Denoise`  in https://github.com/neuromorphs/tonic/commit/6fc4ac2844d9ec77c2868564f615cc509c9607ce