### PR TITLE
returning index in getitem

### DIFF
--- a/tonic/datasets/dvsgesture.py
+++ b/tonic/datasets/dvsgesture.py
@@ -100,7 +100,7 @@ class DVSGesture(VisionDataset):
             events = self.transform(events, self.sensor_size, self.ordering)
         if self.target_transform is not None:
             target = self.target_transform(target)
-        return events, target
+        return events, target, index
 
     def __len__(self):
         return len(self.samples)

--- a/tonic/datasets/ncaltech101.py
+++ b/tonic/datasets/ncaltech101.py
@@ -62,7 +62,7 @@ class NCALTECH101(VisionDataset):
             events = self.transform(events, self.sensor_size, self.ordering)
         if self.target_transform is not None:
             target = self.target_transform(target)
-        return events, target
+        return events, target, index
 
     def __len__(self):
         return len(self.data)

--- a/tonic/datasets/ncars.py
+++ b/tonic/datasets/ncars.py
@@ -90,7 +90,7 @@ class NCARS(VisionDataset):
             events = self.transform(events, self.sensor_size, self.ordering)
         if self.target_transform is not None:
             target = self.target_transform(target)
-        return events, target
+        return events, target, index
 
     def __len__(self):
         return len(self.samples)

--- a/tonic/datasets/nmnist.py
+++ b/tonic/datasets/nmnist.py
@@ -100,7 +100,7 @@ class NMNIST(VisionDataset):
             events = self.transform(events, self.sensor_size, self.ordering)
         if self.target_transform is not None:
             target = self.target_transform(target)
-        return events, target
+        return events, target, index
 
     def __len__(self):
         return len(self.samples)

--- a/tonic/datasets/pokerdvs.py
+++ b/tonic/datasets/pokerdvs.py
@@ -81,7 +81,7 @@ class POKERDVS(VisionDataset):
             events = self.transform(events, self.sensor_size, self.ordering)
         if self.target_transform is not None:
             target = self.target_transform(target)
-        return events, target
+        return events, target, index
 
     def __len__(self):
         return len(self.data)


### PR DESCRIPTION
returns the index in the __getitem__ method for datasets.
the index is useful to easily know which recording we're dealing with when we use a subset or we shuffle the dataset