### PR TITLE
Batching support and small fixes

### DIFF
--- a/tonic/datasets/__init__.py
+++ b/tonic/datasets/__init__.py
@@ -1,4 +1,5 @@
 from .asl_dvs import ASLDVS
+from .dataloader import DataLoader
 from .dvsgesture import DVSGesture
 from .davisdataset import DAVISDATA
 from .hsd import SHD, SSC

--- a/tonic/datasets/dataloader.py
+++ b/tonic/datasets/dataloader.py
@@ -2,11 +2,12 @@ import numpy as np
 
 
 class DataLoader:
-    def __init__(self, dataset, shuffle=False):
+    def __init__(self, dataset, shuffle=False, batch_size=1):
         self.dataset = dataset
         self.length = len(dataset)
-        self.indices = np.arange(0, self.length)
+        self.indices = np.arange(0, self.length, dtype=int)
         self.iteration = 0
+        self.batch_size = batch_size
         if shuffle:
             np.random.shuffle(self.indices)
 
@@ -16,10 +17,16 @@ class DataLoader:
     def __next__(self):
         if self.iteration >= self.length:
             raise StopIteration
-        else:
+        elif self.batch_size == 1:
             data = self.dataset[self.indices[self.iteration]]
             self.iteration += 1
             return data
+        else:
+            begin = self.iteration
+            end = self.iteration + self.batch_size
+            data = self.dataset[self.indices[begin:end]]
+            self.iteration += len(data)
+            return data
 
     def __len__(self):
-        return len(self.dataset)
+        return int(np.ceil(len(self.dataset) / float(self.batch_size)))

--- a/tonic/datasets/dataloader.py
+++ b/tonic/datasets/dataloader.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+from copy import copy
 
 class DataLoader:
     def __init__(self, dataset, shuffle=False, batch_size=1):
@@ -12,7 +13,8 @@ class DataLoader:
             np.random.shuffle(self.indices)
 
     def __iter__(self):
-        return self
+        # Return a copy of data loader so state won't be modified
+        return copy(self)
 
     def __next__(self):
         if self.iteration >= self.length:
@@ -22,10 +24,14 @@ class DataLoader:
             self.iteration += 1
             return data
         else:
+            # Get start and end of batch (end might be past end of indices)
             begin = self.iteration
             end = self.iteration + self.batch_size
+            # Get indices and thus slice of data
             inds = self.indices[begin:end]
             data = self.dataset[inds]
+            # Add number of indices to iteration count
+            # (will take into account size of dataset)
             self.iteration += len(inds)
             return data
 

--- a/tonic/datasets/dataloader.py
+++ b/tonic/datasets/dataloader.py
@@ -24,8 +24,9 @@ class DataLoader:
         else:
             begin = self.iteration
             end = self.iteration + self.batch_size
-            data = self.dataset[self.indices[begin:end]]
-            self.iteration += len(data)
+            inds = self.indices[begin:end]
+            data = self.dataset[inds]
+            self.iteration += len(inds)
             return data
 
     def __len__(self):


### PR DESCRIPTION
I've been having a go at using PyGeNN to train e-prop (http://www.nature.com/articles/s41467-020-17236-y) networks on SHD using Tonic and have fixed/implemented a few things:
- The data loader wasn't exported before
- I think ``DataLoader.__iter__`` should return a copy as otherwise you can't restart iterations at the beginning of a new epoch (perhaps it should also reshuffle the copy's indices if shuffle is required)
- The data loader didn't support batching. I've added preliminary support to the data loader and (for now) to the HSD base class 

If you're happy with the general direction (not knowing PyTorch, I'm not super-familiar with the original data-loader!), let me know and I'll implement batching in the other datasets and add tests.