### PR TITLE
NMNIST integrity check and torch labels

### DIFF
--- a/tonic/datasets/nmnist.py
+++ b/tonic/datasets/nmnist.py
@@ -1,5 +1,7 @@
 import os
 import numpy as np
+from pathlib import Path
+
 from .dataset import Dataset
 from .download_utils import (
     check_integrity,
@@ -117,15 +119,26 @@ class NMNIST(Dataset):
     def __len__(self):
         return len(self.samples)
 
-    def download(self):
-        download_and_extract_archive(
-            self.url,
-            self.location_on_system,
-            filename=self.archive_filename,
-            md5=self.archive_md5,
+    def _check_exists(self) -> bool:
+        folder = Path(self.location_on_system, self.folder_name)
+        file = Path(self.location_on_system, self.filename)
+        return (
+            file.exists()
+            and folder.exists()
+            and folder.is_dir()
+            and len(list(folder.glob("*/*.bin"))) >= 10000
         )
-        extract_archive(os.path.join(self.location_on_system, self.train_filename))
-        extract_archive(os.path.join(self.location_on_system, self.test_filename))
+
+    def download(self):
+        if not self._check_exists():
+            download_and_extract_archive(
+                self.url,
+                self.location_on_system,
+                filename=self.archive_filename,
+                md5=self.archive_md5,
+            )
+            extract_archive(os.path.join(self.location_on_system, self.train_filename))
+            extract_archive(os.path.join(self.location_on_system, self.test_filename))
 
     def _read_dataset_file(self, filename):
         f = open(filename, "rb")

--- a/tonic/utils.py
+++ b/tonic/utils.py
@@ -86,4 +86,4 @@ def pad_tensors(batch):
         )
         samples_output.append(sample)
         targets_output.append(target)
-    return torch.stack(samples_output), targets_output
+    return torch.stack(samples_output), torch.tensor(targets_output)


### PR DESCRIPTION
This PR addresses #117 
It also converts the label list to torch tensors in `utils.pad_tensors`, which is needed for pytorch loss functions