### PR TITLE
Fix spatial downsampling

### DIFF
--- a/test/transforms/test_transforms.py
+++ b/test/transforms/test_transforms.py
@@ -106,10 +106,10 @@ class TestTransforms:
 
         assert np.array_equal(orig_events[:, t_index] * time_factor, events[:, t_index])
         assert np.array_equal(
-            orig_events[:, x_index] * spatial_factor, events[:, x_index]
+            np.floor(orig_events[:, x_index] * spatial_factor), events[:, x_index]
         )
         assert np.array_equal(
-            orig_events[:, y_index] * spatial_factor, events[:, y_index]
+            np.floor(orig_events[:, y_index] * spatial_factor), events[:, y_index]
         )
 
     @pytest.mark.parametrize(

--- a/tonic/functional/resize.py
+++ b/tonic/functional/resize.py
@@ -37,7 +37,7 @@ def spatial_resize_numpy(
     ]
 
     if integer_coordinates:
-        events[:, x_index] = events[:, x_index].round()
-        events[:, y_index] = events[:, y_index].round()
+        events[:, x_index] = np.floor(events[:, x_index])
+        events[:, y_index] = np.floor(events[:, y_index])
 
     return events, sensor_size

--- a/tonic/transforms.py
+++ b/tonic/transforms.py
@@ -163,7 +163,7 @@ class Downsample:
             events, ordering, coefficient=self.time_factor
         )
         events, sensor_size = functional.spatial_resize_numpy(
-            events, sensor_size, ordering, spatial_factor=self.spatial_factor
+            events, sensor_size, ordering, spatial_factor=self.spatial_factor, integer_coordinates=True
         )
         return events, images, sensor_size
 


### PR DESCRIPTION
Previously if, for example, you were trying to downsample DVS 128 data to 32x32 by specifying ``spatial_factor=0.25``:

127 * 0.25 = 31.75  - which isn't a valid coordinate at all so ``integer_coordinates`` needs setting.

And if ``integer_coordinates`` is set, this got rounded up to 32 which isn't a valid coordinate for a 32x32 target.

See my comment in #122 about integer coordinates :smile: 