### PR TITLE
add temporal alignment transform

### DIFF
--- a/test/transforms/test_transforms.py
+++ b/test/transforms/test_transforms.py
@@ -502,4 +502,4 @@ class TestTransforms:
             multi_image=is_multi_image,
         )
 
-        assert np.min(events[:, t_index]) >= 0
+        assert np.min(events[:, t_index]) == 0

--- a/test/transforms/test_transforms.py
+++ b/test/transforms/test_transforms.py
@@ -481,3 +481,25 @@ class TestTransforms:
 
         assert len(events) > len(orig_events)
         assert np.isin(orig_events, events).all()
+
+    @pytest.mark.parametrize("ordering",[("xytp"), ("typx")])
+    def test_transform_time_alignment(self, ordering):
+        (
+            orig_events,
+            orig_images,
+            sensor_size,
+            is_multi_image,
+        ) = utils.create_random_input_with_ordering(ordering)
+        x_index, y_index, t_index, p_index = utils.findXytpPermutation(ordering)
+
+        transform = transforms.TimeAlignment()
+
+        events, images, sensor_size = transform(
+            events=orig_events.copy(),
+            sensor_size=sensor_size,
+            ordering=ordering,
+            images=orig_images.copy(),
+            multi_image=is_multi_image,
+        )
+
+        assert np.min(events[:, t_index]) >= 0

--- a/tonic/transforms.py
+++ b/tonic/transforms.py
@@ -349,6 +349,17 @@ class SpatioTemporalTransform:
             self.roll,
         )
         return events, images, sensor_size
+    
+    
+class TimeAlignment:
+    """Shifts the timestamps to set the first event of all recordings of the dataset to zero.
+    """
+
+    def __call__(self, events, sensor_size, ordering, images=None, multi_image=None):
+        assert "t" in ordering
+        t_index = ordering.index("t")
+        events[:,t_index] -= min(events[:, t_index])
+        return events, images, sensor_size
 
 
 class TimeJitter:


### PR DESCRIPTION
Add a new transform 'TimeAlignment' to remove all temporal offsets in the dataset. All recordings start as t=0. 