### PR TITLE
ToFrame transformation performance increase

### DIFF
--- a/tonic/functional/to_frame.py
+++ b/tonic/functional/to_frame.py
@@ -93,12 +93,10 @@ def to_frame_numpy(
     bins_p = len(np.unique(pols))
     bins_y, bins_x = (range(sensor_size[0] + 1), range(sensor_size[1] + 1))
 
-    frames = np.empty(
+    frames = np.zeros(
         (len(event_slices), bins_p, len(bins_y) - 1, len(bins_x) - 1), dtype=np.uint16
     )
     for i, event_slice in enumerate(event_slices):
-        frames[i] = np.histogramdd(
-            (event_slice[:, p_index], event_slice[:, y_index], event_slice[:, x_index]),
-            bins=(np.arange(bins_p + 1), bins_y, bins_x),
-        )[0]
+        event_slice = event_slice.astype(np.uint16)
+        np.add.at(frames, (i, event_slice[:, p_index], event_slice[:, y_index],  event_slice[:, x_index]), 1)
     return frames


### PR DESCRIPTION
A drastic speed up can be achieved in the `ToFrame`-transformation with minor changes, mainly by replacing the `numpy.histogramdd` with `numpy.add` (see already performance comparision in #126 by @eneftci when comparing tonic and torchneuromorphic, which uses `numpy.add`). 

Profiling the following script (loading NMNIST-dataset with only the `ToFrame`-transformation for 1ms time-slices) using `yappi` as profiler shows a more than 10x faster execution. The `numpy.histogramdd`-function clearly shows up as the bottleneck in the profiling message. Behaviour of the function should stay exactly the same.

Executed script:
```python
import yappi
import tonic
import tonic.transforms as transforms

def generate_tonic_nmnist_dataset(save_to):
    transform = transforms.Compose([transforms.ToFrame(time_window=1000.0)])
    dataset = tonic.datasets.NMNIST(save_to=save_to,
                                    train=False,
                                    transform=transform,
                                    download=False)
    return dataset

def get_timing(dataset, num_iterations=100):
    yappi.set_clock_type("cpu")
    yappi.clear_stats()
    yappi.start()
    for i in range(num_iterations):
        b = dataset[i]
    yappi.stop()
    yappi.get_func_stats().print_all()
    yappi.get_thread_stats().print_all()
    
if __name__ == "__main__":
    save_to = '/local/finkbeiner/data'
    dataset = generate_tonic_nmnist_dataset(save_to)
    get_timing(dataset)
```


Run with `develop`-branch: 6.354393 s of which 6.107632 s are spent in `numpy.histogramadd` 

```console
Clock type: CPU
Ordered by: totaltime, desc

name                                  ncall  tsub      ttot      tavg      
..s/nmnist.py:110 NMNIST.__getitem__  100    0.000699  6.352537  0.063525
../transforms.py:20 Compose.__call__  100    0.000224  6.339839  0.063398
..transforms.py:575 ToFrame.__call__  100    0.000955  6.339615  0.063396
..onal/to_frame.py:12 to_frame_numpy  100    0.166864  6.338661  0.063387
..unction__ internals>:2 histogramdd  30451  0.028283  6.107632  0.000201
../lib/histograms.py:943 histogramdd  30451  1.255092  5.710745  0.000188
..array_function__ internals>:2 ndim  182..  0.201038  1.064394  0.000006
<__array_function__ internals>:2 any  91353  0.113778  0.816934  0.000009
..array_function__ internals>:2 diff  91353  0.113306  0.760145  0.000008
..y/lib/histograms.py:1074 <genexpr>  121..  0.131912  0.727191  0.000006
..umpy/core/fromnumeric.py:3127 ndim  182..  0.166281  0.618087  0.000003
..nction__ internals>:2 searchsorted  91553  0.112947  0.598231  0.000007
..numpy/core/fromnumeric.py:2268 any  91353  0.109009  0.555748  0.000006
..mpy/lib/function_base.py:1164 diff  91353  0.406314  0.524158  0.000006
..e/fromnumeric.py:69 _wrapreduction  91353  0.185361  0.446740  0.000005
..e/fromnumeric.py:1283 searchsorted  91553  0.088104  0.369550  0.000004
..y/core/fromnumeric.py:51 _wrapfunc  91553  0.098699  0.281446  0.000003
..function__ internals>:2 atleast_2d  30451  0.038039  0.219507  0.000007
..ams.py:932 _histogramdd_dispatcher  243..  0.156647  0.201779  0.000001
..y/core/shape_base.py:81 atleast_2d  30451  0.061177  0.145785  0.000005
..n__ internals>:2 ravel_multi_index  30451  0.042214  0.128986  0.000004
..y_function__ internals>:2 bincount  30451  0.039167  0.110486  0.000004
..es/numpy/core/_methods.py:50 _prod  30451  0.022561  0.093896  0.000003
..ges/numpy/core/_methods.py:54 _any  30451  0.024019  0.080653  0.000003
..omnumeric.py:3123 _ndim_dispatcher  182..  0.057300  0.057300  0.000000
../core/fromnumeric.py:70 <dictcomp>  91353  0.047753  0.047753  0.000001
..romnumeric.py:2263 _any_dispatcher  91353  0.030125  0.030125  0.000000
..tion_base.py:1160 _diff_dispatcher  91353  0.029833  0.029833  0.000000
..c.py:1279 _searchsorted_dispatcher  91553  0.029215  0.029215  0.000000
..unctional/utils.py:6 slice_by_time  100    0.001554  0.016669  0.000167
..ontextlib.py:353 suppress.__init__  30451  0.014191  0.014191  0.000000
..t.py:143 NMNIST._read_dataset_file  100    0.004730  0.011999  0.000120
../functional/utils.py:44 <listcomp>  100    0.011942  0.011942  0.000119
..ontextlib.py:359 suppress.__exit__  30451  0.010276  0.010276  0.000000
..py/core/multiarray.py:883 bincount  30451  0.009822  0.009822  0.000000
..ultiarray.py:960 ravel_multi_index  30451  0.009765  0.009765  0.000000
..ntextlib.py:356 suppress.__enter__  30451  0.009605  0.009605  0.000000
.._base.py:77 _atleast_2d_dispatcher  30451  0.009481  0.009481  0.000000
..ray_function__ internals>:2 unique  100    0.000199  0.005325  0.000053
..umpy/lib/arraysetops.py:138 unique  100    0.000249  0.004962  0.000050
..y/lib/arraysetops.py:320 _unique1d  100    0.001155  0.004559  0.000046
..nction__ internals>:2 column_stack  100    0.000141  0.002698  0.000027
..lib/shape_base.py:612 column_stack  100    0.000771  0.002199  0.000022
..unction__ internals>:2 concatenate  100    0.000146  0.000982  0.000010
..rray_function__ internals>:2 where  200    0.000278  0.000761  0.000004
..se.py:608 _column_stack_dispatcher  100    0.000098  0.000234  0.000002
..hon3.8/abc.py:96 __instancecheck__  100    0.000083  0.000203  0.000002
..unctional/to_frame.py:45 <genexpr>  500    0.000165  0.000165  0.000000
..y:207 _arrays_for_stack_dispatcher  100    0.000079  0.000136  0.000001
..b/arraysetops.py:125 _unpack_tuple  100    0.000088  0.000122  0.000001
..numpy/core/multiarray.py:341 where  200    0.000069  0.000069  0.000000
..core/multiarray.py:148 concatenate  100    0.000036  0.000036  0.000000
..aysetops.py:133 _unique_dispatcher  100    0.000036  0.000036  0.000000
..on3.8/abc.py:100 __subclasscheck__  1      0.000002  0.000019  0.000019
..hon3.8/os.py:1073 __subclasshook__  1      0.000004  0.000007  0.000007
..llections_abc.py:72 _check_methods  1      0.000003  0.000003  0.000003

name           id     tid              ttot      scnt        
_MainThread    0      140204795520832  6.354393  1         
```

Run with `toframe_np_add`-branch: 0.254840 s

```console
Clock type: CPU
Ordered by: totaltime, desc

name                                  ncall  tsub      ttot      tavg      
..s/nmnist.py:110 NMNIST.__getitem__  100    0.000580  0.253698  0.002537
../transforms.py:20 Compose.__call__  100    0.000198  0.242347  0.002423
..transforms.py:575 ToFrame.__call__  100    0.000884  0.242149  0.002421
..onal/to_frame.py:12 to_frame_numpy  100    0.048549  0.241265  0.002413
..unctional/utils.py:6 slice_by_time  100    0.001406  0.016095  0.000161
../functional/utils.py:44 <listcomp>  100    0.011812  0.011812  0.000118
..t.py:143 NMNIST._read_dataset_file  100    0.004285  0.010772  0.000108
..ray_function__ internals>:2 unique  100    0.000127  0.005117  0.000051
..umpy/lib/arraysetops.py:138 unique  100    0.000220  0.004848  0.000048
..y/lib/arraysetops.py:320 _unique1d  100    0.001151  0.004482  0.000045
..nction__ internals>:2 searchsorted  200    0.000247  0.002668  0.000013
..nction__ internals>:2 column_stack  100    0.000126  0.002515  0.000025
..e/fromnumeric.py:1283 searchsorted  200    0.000210  0.002181  0.000011
..lib/shape_base.py:612 column_stack  100    0.000693  0.002068  0.000021
..y/core/fromnumeric.py:51 _wrapfunc  200    0.000239  0.001971  0.000010
..unction__ internals>:2 concatenate  100    0.000178  0.000946  0.000009
..rray_function__ internals>:2 where  200    0.000333  0.000803  0.000004
..se.py:608 _column_stack_dispatcher  100    0.000086  0.000209  0.000002
..hon3.8/abc.py:96 __instancecheck__  100    0.000077  0.000175  0.000002
..unctional/to_frame.py:45 <genexpr>  500    0.000153  0.000153  0.000000
..y:207 _arrays_for_stack_dispatcher  100    0.000075  0.000124  0.000001
..b/arraysetops.py:125 _unpack_tuple  100    0.000082  0.000116  0.000001
..numpy/core/multiarray.py:341 where  200    0.000066  0.000066  0.000000
..c.py:1279 _searchsorted_dispatcher  200    0.000066  0.000066  0.000000
..core/multiarray.py:148 concatenate  100    0.000034  0.000034  0.000000
..aysetops.py:133 _unique_dispatcher  100    0.000032  0.000032  0.000000
..on3.8/abc.py:100 __subclasscheck__  1      0.000002  0.000017  0.000017
..hon3.8/os.py:1073 __subclasshook__  1      0.000003  0.000006  0.000006
..llections_abc.py:72 _check_methods  1      0.000003  0.000003  0.000003

name           id     tid              ttot      scnt        
_MainThread    0      139937604044608  0.254840  1   
```