### PR TITLE
Fix frame generation for audio data with polarity>1

### DIFF
--- a/test/test_representations.py
+++ b/test/test_representations.py
@@ -90,7 +90,7 @@ class TestRepresentations:
         assert frames.shape[1:] == sensor_size[::-1]
 
     def test_representation_frame_audio(self):
-        sensor_size = (200, 1, 1\2)
+        sensor_size = (200, 1, 2)
         orig_events, _ = create_random_input(
             sensor_size=sensor_size,
             dtype=np.dtype([("x", int), ("t", int), ("p", int)]),

--- a/test/test_representations.py
+++ b/test/test_representations.py
@@ -87,12 +87,12 @@ class TestRepresentations:
         assert frames.shape[1:] == sensor_size[::-1]
         
     def test_representation_frame_audio(self):
-        sensor_size = (200, 1, 1)
+        sensor_size = (200, 1, 2)
         orig_events, _ = create_random_input(sensor_size=sensor_size, dtype=np.dtype([("x", int), ("t", int), ("p", int)]))
         transform = transforms.ToFrame(sensor_size=sensor_size, time_window=25000)
         frames = transform(orig_events)
 #         breakpoint()
-        assert frames.shape[1:] == sensor_size[1::-1]
+        assert frames.shape[1:] == (sensor_size[0], sensor_size[2])
 
 
     @pytest.mark.parametrize(

--- a/test/test_representations.py
+++ b/test/test_representations.py
@@ -92,7 +92,7 @@ class TestRepresentations:
         transform = transforms.ToFrame(sensor_size=sensor_size, time_window=25000)
         frames = transform(orig_events)
 #         breakpoint()
-        assert frames.shape[1:] == (sensor_size[0], sensor_size[2])
+        assert frames.shape[1:] == (sensor_size[2], sensor_size[0])
 
 
     @pytest.mark.parametrize(

--- a/tonic/functional/to_frame.py
+++ b/tonic/functional/to_frame.py
@@ -84,7 +84,7 @@ def to_frame_numpy(
                 1,
             )
     else:
-        frames = np.zeros((len(event_slices), *sensor_size[1::-1]), dtype=np.int16)
+        frames = np.zeros((len(event_slices), sensor_size[2], sensor_size[0]), dtype=np.int16)
         for i, event_slice in enumerate(event_slices):
             np.add.at(
                 frames,


### PR DESCRIPTION
sensor_size for non-visual data is (x, 1, p).

At the moment the frames that are generated have dimension (t, 1, x) but is filled with data (t, p, x). This commit fixes this issue.