### PR TITLE
Adjusted file extension in CIFAR10DVS

### DIFF
--- a/tonic/datasets/cifar10dvs.py
+++ b/tonic/datasets/cifar10dvs.py
@@ -101,5 +101,5 @@ class CIFAR10DVS(Dataset):
 
     def _check_exists(self):
         return self._is_file_present() and self._folder_contains_at_least_n_files_of_type(
-            1000, ".aedat"
+            1000, ".aedat4"
         )


### PR DESCRIPTION
Corrected the events files extension from `aedat` to `aedat4` to allow the CIFAR10DVS to correctly check that the dataset has been correctly downloaded and unzipped. 