### PR TITLE
Performance improvement in make_structured_array

### DIFF
--- a/tonic/datasets/asl_dvs.py
+++ b/tonic/datasets/asl_dvs.py
@@ -5,6 +5,7 @@ import scipy.io as scio
 from typing import Tuple, Any, Optional
 from tonic.dataset import Dataset
 from tonic.download_utils import extract_archive
+from tonic.io import make_structured_array
 
 
 class ASLDVS(Dataset):
@@ -64,15 +65,13 @@ class ASLDVS(Dataset):
             (events, target) where target is index of the target class.
         """
         events, target = scio.loadmat(self.data[index]), self.targets[index]
-        events = np.column_stack(
-            [
-                events["ts"],
-                events["x"],
-                self.sensor_size[1] - 1 - events["y"],
-                events["pol"],
-            ]
+        events = make_structured_array(
+            events["ts"], 
+            events["x"], 
+            self.sensor_size[1] - 1 - events["y"], 
+            events["pol"], 
+            dtype=self.dtype
         )
-        events = np.lib.recfunctions.unstructured_to_structured(events, self.dtype)
         if self.transform is not None:
             events = self.transform(events)
         if self.target_transform is not None:

--- a/tonic/datasets/davisdataset.py
+++ b/tonic/datasets/davisdataset.py
@@ -4,6 +4,7 @@ from numpy.lib import recfunctions
 from importRosbag.importRosbag import importRosbag
 from tonic.dataset import Dataset
 from tonic.download_utils import check_integrity, download_url
+from tonic.io import make_structured_array
 
 
 class DAVISDATA(Dataset):
@@ -96,10 +97,14 @@ class DAVISDATA(Dataset):
         events = topics["/dvs/events"]
         events["ts"] -= events["ts"][0]
         events["ts"] *= 1e6
-        events = np.column_stack(
-            (events["ts"], events["x"], events["y"], events["pol"])
+        events = make_structured_array(
+            events["ts"], 
+            events["x"], 
+            events["y"], 
+            events["pol"], 
+            dtype=self.dtype
         )
-        events = np.lib.recfunctions.unstructured_to_structured(events, self.dtype)
+        
         if "/dvs/imu" in topics.keys():
             imu = topics["/dvs/imu"]
             imu["ts"] = ((imu["ts"] - imu["ts"][0]) * 1e6).astype(int)

--- a/tonic/datasets/dsec.py
+++ b/tonic/datasets/dsec.py
@@ -9,6 +9,7 @@ from tonic.download_utils import (
     download_url,
     list_files,
 )
+from tonic.io import make_structured_array
 
 
 class DSEC(Dataset):
@@ -167,31 +168,23 @@ class DSEC(Dataset):
         events_left_file = h5py.File(
             os.path.join(base_folder, "events_left", "events.h5")
         )["events"]
-        events_left = np.column_stack(
-            (
+        events_left = make_structured_array(
                 events_left_file["x"][()],
                 events_left_file["y"][()],
                 events_left_file["t"][()],
                 events_left_file["p"][()],
-            )
-        )
-        events_left = np.lib.recfunctions.unstructured_to_structured(
-            events_left, self.dtype
+                dtype=self.dtype
         )
 
         events_right_file = h5py.File(
             os.path.join(base_folder, "events_right", "events.h5")
         )["events"]
-        events_right = np.column_stack(
-            (
+        events_right = make_structured_array(
                 events_right_file["x"][()],
                 events_right_file["y"][()],
                 events_right_file["t"][()],
                 events_right_file["p"][()],
-            )
-        )
-        events_right = np.lib.recfunctions.unstructured_to_structured(
-            events_right, self.dtype
+                dtype=self.dtype
         )
 
         # images

--- a/tonic/datasets/mvsec.py
+++ b/tonic/datasets/mvsec.py
@@ -3,6 +3,7 @@ import numpy as np
 from importRosbag.importRosbag import importRosbag
 from tonic.dataset import Dataset
 from tonic.download_utils import check_integrity, download_url
+from tonic.io import make_structured_array
 
 
 class MVSEC(Dataset):
@@ -92,25 +93,23 @@ class MVSEC(Dataset):
         events_left = topics["/davis/left/events"]
         events_left["ts"] -= events_left["ts"][0]
         events_left["ts"] *= 1e6
-        events_left = np.column_stack(
-            (events_left["x"], events_left["y"], events_left["ts"], events_left["pol"])
+        events_left = make_structured_array(
+            events_left["x"], 
+            events_left["y"], 
+            events_left["ts"], 
+            events_left["pol"],
+            dtype=self.dtype
         )
-        events_left = np.lib.recfunctions.unstructured_to_structured(
-            events_left, self.dtype
-        )
+
         events_right = topics["/davis/right/events"]
         events_right["ts"] -= events_right["ts"][0]
         events_right["ts"] *= 1e6
-        events_right = np.column_stack(
-            (
-                events_right["x"],
-                events_right["y"],
-                events_right["ts"],
-                events_right["pol"],
-            )
-        )
-        events_right = np.lib.recfunctions.unstructured_to_structured(
-            events_right, self.dtype
+        events_right = make_structured_array(
+            events_right["x"],
+            events_right["y"],
+            events_right["ts"],
+            events_right["pol"],
+            dtype=self.dtype
         )
         imu_left = topics["/davis/left/imu"]
         imu_right = topics["/davis/right/imu"]

--- a/tonic/datasets/s_mnist.py
+++ b/tonic/datasets/s_mnist.py
@@ -3,6 +3,7 @@ import numpy as np
 from struct import unpack
 from tonic.dataset import Dataset
 from tonic.download_utils import download_and_extract_archive, extract_archive
+from tonic.io import make_structured_array
 
 
 class SMNIST(Dataset):
@@ -167,10 +168,12 @@ class SMNIST(Dataset):
             spike_time[1::2] = double_spike_time + 1
 
         # stack and add artificial polarity of 1
-        events = np.column_stack(
-            (spike_time * self.dt, spike_idx, np.ones(spike_idx.shape[0]))
+        events = make_structured_array(
+            spike_time * self.dt, 
+            spike_idx, 
+            1, 
+            dtype=self.dtype
         )
-        events = np.lib.recfunctions.unstructured_to_structured(events, self.dtype)
         target = self.label_data[index]
 
         if self.transform is not None:

--- a/tonic/datasets/tum_vie.py
+++ b/tonic/datasets/tum_vie.py
@@ -11,6 +11,7 @@ from tonic.download_utils import (
     list_files,
 )
 from typing import Union, List, Callable, Optional
+from tonic.io import make_structured_array
 
 
 class TUMVIE(Dataset):
@@ -123,31 +124,23 @@ class TUMVIE(Dataset):
         events_left_file = h5py.File(
             os.path.join(base_folder, self.selection[index] + "-events_left.h5")
         )["events"]
-        events_left = np.column_stack(
-            (
-                events_left_file["p"][()],
-                events_left_file["t"][()],
-                events_left_file["x"][()],
-                events_left_file["y"][()],
-            )
-        )
-        events_left = np.lib.recfunctions.unstructured_to_structured(
-            events_left, self.dtype
+        events_left = make_structured_array(
+            events_left_file["p"][()],
+            events_left_file["t"][()],
+            events_left_file["x"][()],
+            events_left_file["y"][()],
+            dtype=self.dtype
         )
 
         events_right_file = h5py.File(
             os.path.join(base_folder, self.selection[index] + "-events_right.h5")
         )["events"]
-        events_right = np.column_stack(
-            (
-                events_right_file["p"][()],
-                events_right_file["t"][()],
-                events_right_file["x"][()],
-                events_right_file["y"][()],
-            )
-        )
-        events_right = np.lib.recfunctions.unstructured_to_structured(
-            events_right, self.dtype
+        events_right = make_structured_array(
+            events_right_file["p"][()],
+            events_right_file["t"][()],
+            events_right_file["x"][()],
+            events_right_file["y"][()],
+            dtype=self.dtype
         )
 
         imu_data = []

--- a/tonic/datasets/visual_place_recognition.py
+++ b/tonic/datasets/visual_place_recognition.py
@@ -1,6 +1,7 @@
 import os
 import numpy as np
 from importRosbag.importRosbag import importRosbag
+from tonic.io import make_structured_array
 from tonic.dataset import Dataset
 from tonic.download_utils import check_integrity, download_url
 
@@ -80,10 +81,13 @@ class VPR(Dataset):
         events = topics["/dvs/events"]
         events["ts"] -= events["ts"][0]
         events["ts"] *= 1e6
-        events = np.column_stack(
-            (events["ts"], events["x"], events["y"], events["pol"])
+        events = make_structured_array(
+            events["ts"], 
+            events["x"], 
+            events["y"], 
+            events["pol"], 
+            dtype=self.dtype
         )
-        events = np.lib.recfunctions.unstructured_to_structured(events, self.dtype)
         imu = topics["/dvs/imu"]
         imu["ts"] = ((imu["ts"] - imu["ts"][0]) * 1e6).astype(int)
         images = topics["/dvs/image_raw"]

--- a/tonic/io.py
+++ b/tonic/io.py
@@ -3,10 +3,11 @@ import struct
 import numpy as np
 
 
-events_struct = [("x", np.int16), ("y", np.int16), ("t", np.int64), ("p", bool)]
+events_struct = np.dtype([("x", np.int16), ("y", np.int16), ("t", np.int64), ("p", bool)])
 
 # many functions in this file have been copied from https://gitlab.com/synsense/aermanager/-/blob/master/aermanager/parsers.py
-def make_structured_array(x, y, t, p, dtype=events_struct):
+def make_structured_array(*args, dtype=events_struct):
+    # TODO change the docstring
     """
     Make a structured array given lists of x, y, t, p
 
@@ -18,11 +19,12 @@ def make_structured_array(x, y, t, p, dtype=events_struct):
     Returns:
         xytp: numpy structured array
     """
-    struct_arr = np.empty_like(x, dtype=dtype)
-    struct_arr["x"] = x
-    struct_arr["y"] = y
-    struct_arr["t"] = t
-    struct_arr["p"] = p
+    assert not isinstance(args[-1], np.dtype), "The `dtype` must be provided as a keyword argument."
+    names = dtype.names
+    assert len(args) == len(names)
+    struct_arr = np.empty_like(args[0], dtype=dtype)
+    for arg,name in zip(args,names):
+        struct_arr[name] = arg
     return struct_arr
 
 

--- a/tonic/io.py
+++ b/tonic/io.py
@@ -8,7 +8,7 @@ events_struct = np.dtype([("x", np.int16), ("y", np.int16), ("t", np.int64), ("p
 # many functions in this file have been copied from https://gitlab.com/synsense/aermanager/-/blob/master/aermanager/parsers.py
 def make_structured_array(*args, dtype=events_struct):
     """
-    Make a structured array given a varaibale number of argument values
+    Make a structured array given a variable number of argument values
 
     Args:
         *args: Values in the form of nested lists or tuples or numpy arrays. Every except the first argument can be of a primitive data type like int or float

--- a/tonic/io.py
+++ b/tonic/io.py
@@ -174,7 +174,7 @@ def read_mnist_file(bin_file, dtype):
         all_y[td_indices],
         all_ts[td_indices],
         all_p[td_indices],
-        dtype,
+        dtype=dtype,
     )
     return xytp
 

--- a/tonic/io.py
+++ b/tonic/io.py
@@ -7,17 +7,13 @@ events_struct = np.dtype([("x", np.int16), ("y", np.int16), ("t", np.int64), ("p
 
 # many functions in this file have been copied from https://gitlab.com/synsense/aermanager/-/blob/master/aermanager/parsers.py
 def make_structured_array(*args, dtype=events_struct):
-    # TODO change the docstring
     """
-    Make a structured array given lists of x, y, t, p
+    Make a structured array given a varaibale number of argument values
 
     Args:
-        x: List of x values
-        y: List of y values
-        t: List of times
-        p: List of polarities boolean
+        *args: Values in the form of nested lists or tuples or numpy arrays. Every except the first argument can be of a primitive data type like int or float
     Returns:
-        xytp: numpy structured array
+        struct_arr: numpy structured array with the shape of the first argument
     """
     assert not isinstance(args[-1], np.dtype), "The `dtype` must be provided as a keyword argument."
     names = dtype.names

--- a/tonic/io.py
+++ b/tonic/io.py
@@ -18,7 +18,12 @@ def make_structured_array(x, y, t, p, dtype=events_struct):
     Returns:
         xytp: numpy structured array
     """
-    return np.fromiter(zip(x, y, t, p), dtype=dtype)
+    struct_arr = np.empty_like(x, dtype=dtype)
+    struct_arr["x"] = x
+    struct_arr["y"] = y
+    struct_arr["t"] = t
+    struct_arr["p"] = p
+    return struct_arr
 
 
 def read_aedat4(in_file):


### PR DESCRIPTION
Creating the structured arrays in the function `make_structured_array` the proposed way is much faster than the previous method of calling `np.fromiter`. The result is an e.g. 5-10x faster loading time for a plain NMNIST dataset without transformations. This translates to roughly half the time spent if one adds a typical `ToFrame` transformation. (Results see below.)

Additionally, the proposed implementation allows to create multi-dimensional structured arrays, if that is a feature you would like.

The only functional difference I see is that the proposed implementation expects all input lists/arrays to have identical length/shape. If you want to make sure that the behavior stays exactly the same (no error messages for different length vectors), I could add that. Although, I am not sure whether that really helps or could rather create unexpected behavior.

Maybe there is an even cleaner one-liner that accomplishes the same thing, but I couldn't find one...

For rough profiling I use the following script, with the transforms only optionally enabled: 
(Obviously exact times depend on many things, but this should give a good impression.)
```python
import yappi
import tonic
import tonic.transforms as transforms

def generate_tonic_nmnist_dataset(save_to):
    # transform = transforms.Compose([transforms.ToFrame(tonic.datasets.NMNIST.sensor_size, n_time_bins=100)])
    transform = None
    dataset = tonic.datasets.NMNIST(save_to=save_to,
                                    train=False,
                                    transform=transform,
                                    )
    return dataset

def get_timing(dataset, num_iterations=1000):
    yappi.set_clock_type("cpu")
    yappi.clear_stats()
    yappi.start()
    for i in range(num_iterations):
        b = dataset[i]
    yappi.stop()
    yappi.get_func_stats().print_all()
    yappi.get_thread_stats().print_all()
    
if __name__ == "__main__":
    dataset = generate_tonic_nmnist_dataset(<root_path>)
    get_timing(dataset)
```

Run with `develop`-branch, no transformations: 1.287512 s of which 1.177169 s are spent in `make_structured_array`
```console
Clock type: CPU
Ordered by: totaltime, desc

name                                  ncall  tsub      ttot      tavg      
..ts/nmnist.py:96 NMNIST.__getitem__  1000   0.002342  1.286641  0.001287
..rk/tonic/io.py:141 read_mnist_file  1000   0.065487  1.284299  0.001284
..onic/io.py:9 make_structured_array  1000   0.001736  1.177169  0.001177
..ay_function__ internals>:177 where  2000   0.002690  0.008820  0.000004
..hon3.8/abc.py:96 __instancecheck__  1000   0.000704  0.001359  0.000001
..numpy/core/multiarray.py:341 where  2000   0.000657  0.000657  0.000000
..on3.8/abc.py:100 __subclasscheck__  1      0.000002  0.000018  0.000018
..hon3.8/os.py:1073 __subclasshook__  1      0.000005  0.000008  0.000008
..llections_abc.py:72 _check_methods  1      0.000003  0.000003  0.000003

name           id     tid              ttot      scnt        
_MainThread    0      139773862672192  1.287512  1
```

Run with `make_struct_array`-branch, with transformations: 0.203821 s of which 0.023600 s are spent in `make_structured_array`:
```console
Clock type: CPU
Ordered by: totaltime, desc

name                                  ncall  tsub      ttot      tavg      
..ts/nmnist.py:96 NMNIST.__getitem__  1000   0.003610  0.202481  0.000202
..rk/tonic/io.py:147 read_mnist_file  1000   0.105432  0.198871  0.000199
..onic/io.py:9 make_structured_array  1000   0.021730  0.023600  0.000024
..ay_function__ internals>:177 where  2000   0.004408  0.014345  0.000007
..hon3.8/abc.py:96 __instancecheck__  1000   0.001115  0.002287  0.000002
..numpy/core/multiarray.py:341 where  2000   0.001078  0.001078  0.000001
..on3.8/abc.py:100 __subclasscheck__  1      0.000003  0.000019  0.000019
..hon3.8/os.py:1073 __subclasshook__  1      0.000005  0.000009  0.000009
..llections_abc.py:72 _check_methods  1      0.000004  0.000004  0.000004

name           id     tid              ttot      scnt        
_MainThread    0      139862767404864  0.203821  1 
```

For a more realistic reference, now with a typical ToFrame transformation:

Run with `develop`-branch, with transformations: 2.410332 s of which 1.337040 s are spent in `make_structured_array`:
```console
Clock type: CPU
Ordered by: totaltime, desc

name                                  ncall  tsub      ttot      tavg      
..ts/nmnist.py:96 NMNIST.__getitem__  1000   0.005548  2.409219  0.002409
..rk/tonic/io.py:141 read_mnist_file  1000   0.079679  1.503032  0.001503
..onic/io.py:9 make_structured_array  1000   0.002423  1.337040  0.001337
../transforms.py:24 Compose.__call__  1000   0.001427  0.900639  0.000901
..transforms.py:512 ToFrame.__call__  1000   0.004597  0.899212  0.000899
..onal/to_frame.py:11 to_frame_numpy  1000   0.139583  0.894614  0.000895
..l/slicing.py:52 slice_by_time_bins  1000   0.012971  0.065715  0.000066
..unctional/slicing.py:79 <listcomp>  1000   0.029272  0.029272  0.000029
..tion__ internals>:177 searchsorted  2000   0.002771  0.021451  0.000011
..e/fromnumeric.py:1319 searchsorted  2000   0.002394  0.015916  0.000008
..y/core/fromnumeric.py:51 _wrapfunc  2000   0.002602  0.013523  0.000007
..ay_function__ internals>:177 where  2000   0.003402  0.010860  0.000005
..hon3.8/abc.py:96 __instancecheck__  1000   0.000881  0.001836  0.000002
..unctional/to_frame.py:40 <genexpr>  5000   0.001782  0.001782  0.000000
..numpy/core/multiarray.py:341 where  2000   0.000764  0.000764  0.000000
..c.py:1315 _searchsorted_dispatcher  2000   0.000717  0.000717  0.000000
..on3.8/abc.py:100 __subclasscheck__  1      0.000002  0.000017  0.000017
..hon3.8/os.py:1073 __subclasshook__  1      0.000005  0.000009  0.000009
..llections_abc.py:72 _check_methods  1      0.000004  0.000004  0.000004

name           id     tid              ttot      scnt        
_MainThread    0      140369934112576  2.410332  1 
```

Run with `make_struct_array`-branch, with transformations: 0.905932 s of which 0.014391 s are spent in `make_structured_array`:
```console
Clock type: CPU
Ordered by: totaltime, desc

name                                  ncall  tsub      ttot      tavg      
..ts/nmnist.py:96 NMNIST.__getitem__  1000   0.004371  0.905062  0.000905
../transforms.py:24 Compose.__call__  1000   0.001174  0.765604  0.000766
..transforms.py:512 ToFrame.__call__  1000   0.003779  0.764430  0.000764
..onal/to_frame.py:11 to_frame_numpy  1000   0.118857  0.760651  0.000761
..rk/tonic/io.py:147 read_mnist_file  1000   0.064431  0.135087  0.000135
..l/slicing.py:52 slice_by_time_bins  1000   0.010255  0.052905  0.000053
..unctional/slicing.py:79 <listcomp>  1000   0.023806  0.023806  0.000024
..tion__ internals>:177 searchsorted  2000   0.002236  0.017216  0.000009
..onic/io.py:9 make_structured_array  1000   0.013023  0.014391  0.000014
..e/fromnumeric.py:1319 searchsorted  2000   0.001916  0.012649  0.000006
..y/core/fromnumeric.py:51 _wrapfunc  2000   0.002158  0.010734  0.000005
..ay_function__ internals>:177 where  2000   0.002772  0.008950  0.000004
..hon3.8/abc.py:96 __instancecheck__  1000   0.000730  0.001474  0.000001
..unctional/to_frame.py:40 <genexpr>  5000   0.001458  0.001458  0.000000
..numpy/core/multiarray.py:341 where  2000   0.000649  0.000649  0.000000
..c.py:1315 _searchsorted_dispatcher  2000   0.000596  0.000596  0.000000
..on3.8/abc.py:100 __subclasscheck__  1      0.000002  0.000018  0.000018
..hon3.8/os.py:1073 __subclasshook__  1      0.000005  0.000010  0.000010
..llections_abc.py:72 _check_methods  1      0.000004  0.000004  0.000004

name           id     tid              ttot      scnt        
_MainThread    0      139919624488768  0.905932  1
```
