### PR TITLE
[New Event Representation]: Bina-Rep event frames

### DIFF
--- a/docs/reference/transformations.rst
+++ b/docs/reference/transformations.rst
@@ -110,6 +110,10 @@ Voxel grid
 ^^^^^^^^^^^
 .. autoclass:: ToVoxelGrid
 
+Bina-Rep event frames
+^^^^^^^^^^^^^^^^^^^^^
+.. autoclass:: ToBinaRep
+
 
 Target transforms
 -----------------

--- a/test/test_representations.py
+++ b/test/test_representations.py
@@ -82,7 +82,6 @@ class TestRepresentations:
 
         assert frames is not orig_events
 
-
     @pytest.mark.parametrize(
         "time_window, event_count, n_time_bins, n_event_bins, overlap,"
         " include_incomplete, sensor_size",
@@ -112,7 +111,9 @@ class TestRepresentations:
         sensor_size,
     ):
         n_events = 10000
-        orig_events, sensor_size = create_random_input(sensor_size=sensor_size, n_events=n_events)
+        orig_events, sensor_size = create_random_input(
+            sensor_size=sensor_size, n_events=n_events
+        )
 
         transform = transforms.ToSparseTensor(
             sensor_size=sensor_size,
@@ -158,11 +159,12 @@ class TestRepresentations:
 
         if n_event_bins is not None:
             assert sparse_tensor.shape[0] == n_event_bins
-            assert sparse_tensor[0].to_dense().sum() == (1 + overlap) * (n_events // n_event_bins)
+            assert sparse_tensor[0].to_dense().sum() == (1 + overlap) * (
+                n_events // n_event_bins
+            )
 
         assert sparse_tensor is not orig_events
 
-        
     def test_representation_frame_inferred(self):
         sensor_size = (20, 10, 2)
         orig_events, _ = create_random_input(n_events=30000, sensor_size=sensor_size)
@@ -208,18 +210,31 @@ class TestRepresentations:
             assert surfaces.shape[3] == sensor_size[0]
         assert surfaces is not orig_events
 
-    @pytest.mark.parametrize("surface_size, cell_size, tau, num_workers, decay", [(7, 9, 100, 1, "lin"), (3, 4, 1000, 1, "exp")])
-    def test_representation_avg_time_surface(self, surface_size, cell_size, tau, num_workers, decay):
+    @pytest.mark.parametrize(
+        "surface_size, cell_size, tau, num_workers, decay",
+        [(7, 9, 100, 1, "lin"), (3, 4, 1000, 1, "exp")],
+    )
+    def test_representation_avg_time_surface(
+        self, surface_size, cell_size, tau, num_workers, decay
+    ):
         orig_events, sensor_size = create_random_input(n_events=1000)
 
         transform = transforms.ToAveragedTimesurface(
-            sensor_size=sensor_size, surface_size=surface_size, cell_size=cell_size, tau=tau, num_workers=num_workers, decay=decay
+            sensor_size=sensor_size,
+            surface_size=surface_size,
+            cell_size=cell_size,
+            tau=tau,
+            num_workers=num_workers,
+            decay=decay,
         )
 
         surfaces = transform(orig_events)
-        import math 
+        import math
+
         assert len(surfaces.shape) == 4
-        assert surfaces.shape[0] == math.ceil(sensor_size[0]/cell_size)*math.ceil(sensor_size[1]/cell_size)
+        assert surfaces.shape[0] == math.ceil(sensor_size[0] / cell_size) * math.ceil(
+            sensor_size[1] / cell_size
+        )
         assert surfaces.shape[1] == sensor_size[2]
         assert surfaces.shape[2] == surface_size
         assert surfaces.shape[3] == surface_size
@@ -236,3 +251,28 @@ class TestRepresentations:
         volume = transform(orig_events)
         assert volume.shape == (n_time_bins, *sensor_size[1::-1])
         assert volume is not orig_events
+
+    @pytest.mark.parametrize(
+        "n_frames, n_bits",
+        [(1, 8), (2, 8), (3, 8), (1, 16), (2, 16)],
+    )
+    def test_bina_rep(self, n_frames, n_bits):
+        n_events = 10000
+        sensor_size = (128, 128, 2)
+
+        orig_events, _ = create_random_input(sensor_size=sensor_size, n_events=n_events)
+
+        transform = transforms.ToBinaRep(
+            n_frames=n_frames,
+            n_bits=n_bits,
+            to_frame_transform=transforms.ToFrame(
+                sensor_size, n_time_bins=n_frames * n_bits
+            ),
+        )
+
+        frames = transform(orig_events)
+
+        assert len(frames.shape) == 4
+        assert frames.shape[0] == n_frames
+        assert frames.shape[1:] == sensor_size[::-1]
+        assert frames is not orig_events

--- a/test/test_representations.py
+++ b/test/test_representations.py
@@ -262,12 +262,16 @@ class TestRepresentations:
 
         orig_events, _ = create_random_input(sensor_size=sensor_size, n_events=n_events)
 
-        transform = transforms.ToBinaRep(
-            n_frames=n_frames,
-            n_bits=n_bits,
-            to_frame_transform=transforms.ToFrame(
-                sensor_size, n_time_bins=n_frames * n_bits
-            ),
+        transform = transforms.Compose(
+            [
+                transforms.ToFrame(
+                    sensor_size=sensor_size, n_time_bins=n_frames * n_bits
+                ),
+                transforms.ToBinaRep(
+                    n_frames=n_frames,
+                    n_bits=n_bits,
+                ),
+            ]
         )
 
         frames = transform(orig_events)

--- a/tonic/functional/__init__.py
+++ b/tonic/functional/__init__.py
@@ -16,6 +16,7 @@ from .to_averaged_timesurface import to_averaged_timesurface
 from .to_frame import to_frame_numpy
 from .to_timesurface import to_timesurface_numpy
 from .to_voxel_grid import to_voxel_grid_numpy
+from .to_bina_rep import to_bina_rep_numpy
 
 __all__ = [
     "crop_numpy",
@@ -31,4 +32,5 @@ __all__ = [
     "to_frame_numpy",
     "to_timesurface_numpy",
     "to_voxel_grid_numpy",
+    "to_bina_rep_numpy",
 ]

--- a/tonic/functional/to_bina_rep.py
+++ b/tonic/functional/to_bina_rep.py
@@ -12,11 +12,13 @@ def to_bina_rep_numpy(
     To do so, N binary frames are interpreted as a single frame of N-bit representation. Taken from the paper
     Barchid et al. 2022, Bina-Rep Event Frames: a Simple and Effective Representation for Event-based cameras
     https://arxiv.org/pdf/2202.13662.pdf
+    
     Parameters:
         events: numpy.ndarray of shape [num_events, num_event_channels].
         to_frame_transform (tonic.transforms.ToFrame): the ToFrame transform that creates the T*B binary event frames.
         n_frames (int): the number T of bina-rep frames.
         n_bits (int): the number N of bits used in the N-bit representation.
+        
     Returns:
         (numpy.ndarray) the sequence of bina-rep event frames with dimensions (TxPxHxW).
     """

--- a/tonic/functional/to_bina_rep.py
+++ b/tonic/functional/to_bina_rep.py
@@ -11,12 +11,12 @@ def to_bina_rep_numpy(
     To do so, N binary frames are interpreted as a single frame of N-bit representation. Taken from the paper
     Barchid et al. 2022, Bina-Rep Event Frames: a Simple and Effective Representation for Event-based cameras
     https://arxiv.org/pdf/2202.13662.pdf
-    
+
     Parameters:
         event_frames: numpy.ndarray of shape (T*BxPxHxW). The sequence of event frames.
         n_frames (int): the number T of bina-rep frames.
         n_bits (int): the number N of bits used in the N-bit representation.
-        
+
     Returns:
         (numpy.ndarray) the sequence of bina-rep event frames with dimensions (TxPxHxW).
     """

--- a/tonic/functional/to_bina_rep.py
+++ b/tonic/functional/to_bina_rep.py
@@ -22,7 +22,7 @@ def to_bina_rep_numpy(
     Returns:
         (numpy.ndarray) the sequence of bina-rep event frames with dimensions (TxPxHxW).
     """
-    assert "x" and "t" and "p" in events.dtype.names
+    assert "x" and "y" and "t" and "p" in events.dtype.names
     assert (
         to_frame_transform is not None
         and type(to_frame_transform).__name__ == "ToFrame"

--- a/tonic/functional/to_bina_rep.py
+++ b/tonic/functional/to_bina_rep.py
@@ -62,4 +62,4 @@ def bina_rep(frames: np.ndarray) -> np.ndarray:
     mask = np.stack(arr_mask, axis=-1)
     mask = np.reshape(mask, frames.shape)
 
-    return np.sum(mask * frames, 0) / (mask.shape[0] ** 2)
+    return np.sum(mask * frames, 0) / (2**mask.shape[0] -1)

--- a/tonic/functional/to_bina_rep.py
+++ b/tonic/functional/to_bina_rep.py
@@ -1,0 +1,67 @@
+import numpy as np
+import math
+from tonic.transforms import ToFrame
+
+
+def to_bina_rep_numpy(
+    events: np.ndarray,
+    to_frame_transform: ToFrame,
+    n_frames: int = 1,
+    n_bits: int = 8,
+):
+    """Representation that takes T*B binary event frames to produce a sequence of T frames of N-bit numbers.
+    To do so, N binary frames are interpreted as a single frame of N-bit representation. Taken from the paper
+    Barchid et al. 2022, Bina-Rep Event Frames: a Simple and Effective Representation for Event-based cameras
+    https://arxiv.org/pdf/2202.13662.pdf
+    Parameters:
+        events: numpy.ndarray of shape [num_events, num_event_channels].
+        to_frame_transform (tonic.transforms.ToFrame): the ToFrame transform that creates the T*B binary event frames.
+        n_frames (int): the number T of bina-rep frames.
+        n_bits (int): the number N of bits used in the N-bit representation.
+    Returns:
+        (numpy.ndarray) the sequence of bina-rep event frames with dimensions (TxPxHxW).
+    """
+    assert "x" and "t" and "p" in events.dtype.names
+    assert to_frame_transform is not None and type(to_frame_transform) == ToFrame
+    assert n_frames >= 1
+    assert n_bits >= 2
+    
+    ev_frames = to_frame_transform(events)
+
+    if ev_frames.shape[0] != n_bits * n_frames:
+        raise ValueError(
+            "to_frame_transform must create the right number of event frames to the targeted"
+            f"sequence of {n_frames} bina-rep event frames of {n_bits}-bit representation."
+            f"Obtained: {ev_frames.shape[0]} frames. Expected: {n_frames}x{n_bits}={n_bits * n_frames} frames."
+        )
+
+    ev_frames = (ev_frames > 0).astype(np.float32)  # get binary event_frames
+
+    bina_rep_seq = np.zeros((n_frames, *ev_frames.shape[1:]), dtype=np.float32)
+
+    for i in range(n_frames):
+        frames = ev_frames[i * n_bits : (i + 1) * n_bits]
+        bina_rep_frame = bina_rep(frames)
+        bina_rep_seq[i] = bina_rep_frame
+
+    return bina_rep_seq
+
+
+def bina_rep(frames: np.ndarray) -> np.ndarray:
+    """Computes one Bina-Rep frame from the sequence of N binary event-frames in parameter.
+
+    Args:
+        frames (numpy.ndarray): the sequence of N binary event frames used to compute the bina-rep frame. Shape=(NxPxHxW)
+
+    Returns:
+        numpy.ndarray: the resulting bina-rep event frame. Shape=(PxHxW)
+    """
+    mask = 2 ** np.arange(frames.shape[0] - 1, -1, -1, dtype=np.float32)
+    arr_mask = [
+        mask
+        for _ in range(frames.shape[1] * frames.shape[2] * frames.shape[3])
+    ]
+    mask = np.stack(arr_mask, axis=-1)
+    mask = np.reshape(mask, frames.shape)
+
+    return np.sum(mask * frames, 0) / (mask.shape[0] ** 2)

--- a/tonic/functional/to_bina_rep.py
+++ b/tonic/functional/to_bina_rep.py
@@ -1,6 +1,7 @@
 import numpy as np
 import math
 
+
 def to_bina_rep_numpy(
     events: np.ndarray,
     to_frame_transform,
@@ -20,10 +21,13 @@ def to_bina_rep_numpy(
         (numpy.ndarray) the sequence of bina-rep event frames with dimensions (TxPxHxW).
     """
     assert "x" and "t" and "p" in events.dtype.names
-    assert to_frame_transform is not None and type(to_frame_transform).__name__ == "ToFrame"
+    assert (
+        to_frame_transform is not None
+        and type(to_frame_transform).__name__ == "ToFrame"
+    )
     assert n_frames >= 1
     assert n_bits >= 2
-    
+
     ev_frames = to_frame_transform(events)
 
     if ev_frames.shape[0] != n_bits * n_frames:
@@ -56,10 +60,9 @@ def bina_rep(frames: np.ndarray) -> np.ndarray:
     """
     mask = 2 ** np.arange(frames.shape[0] - 1, -1, -1, dtype=np.float32)
     arr_mask = [
-        mask
-        for _ in range(frames.shape[1] * frames.shape[2] * frames.shape[3])
+        mask for _ in range(frames.shape[1] * frames.shape[2] * frames.shape[3])
     ]
     mask = np.stack(arr_mask, axis=-1)
     mask = np.reshape(mask, frames.shape)
 
-    return np.sum(mask * frames, 0) / (2**mask.shape[0] -1)
+    return np.sum(mask * frames, 0) / (2 ** mask.shape[0] - 1)

--- a/tonic/functional/to_bina_rep.py
+++ b/tonic/functional/to_bina_rep.py
@@ -1,11 +1,9 @@
 import numpy as np
 import math
-from tonic.transforms import ToFrame
-
 
 def to_bina_rep_numpy(
     events: np.ndarray,
-    to_frame_transform: ToFrame,
+    to_frame_transform,
     n_frames: int = 1,
     n_bits: int = 8,
 ):
@@ -22,7 +20,7 @@ def to_bina_rep_numpy(
         (numpy.ndarray) the sequence of bina-rep event frames with dimensions (TxPxHxW).
     """
     assert "x" and "t" and "p" in events.dtype.names
-    assert to_frame_transform is not None and type(to_frame_transform) == ToFrame
+    assert to_frame_transform is not None and type(to_frame_transform).__name__ == "ToFrame"
     assert n_frames >= 1
     assert n_bits >= 2
     

--- a/tonic/transforms.py
+++ b/tonic/transforms.py
@@ -643,7 +643,7 @@ class ToVoxelGrid:
         )
 
 
-@dataclass(frozen=True)
+@dataclass()
 class ToBinaRep:
     """Representation that takes T*B binary event frames to produce a sequence of T frames of N-bit numbers.
     To do so, N binary frames are interpreted as a single frame of N-bit representation. Taken from the paper
@@ -655,9 +655,9 @@ class ToBinaRep:
         n_bits (int): the number N of bits used in the N-bit representation.
     """
 
+    n_frames: Optional[int] = 1
+    n_bits: Optional[int] = 8
     to_frame_transform: Optional[ToFrame] = None
-    n_frames: Optional[int] = (1,)
-    n_bits: Optional[int] = (8,)
 
     def __post_init__(self):
         if self.to_frame_transform is None:

--- a/tonic/transforms.py
+++ b/tonic/transforms.py
@@ -38,17 +38,17 @@ class Compose:
 @dataclass
 class CropTime:
     """Drops events with timestamps below min and above max."""
-    
+
     min: int = None
     max: int = None
 
     def __call__(self, events):
-        assert 't' in events.dtype.names
+        assert "t" in events.dtype.names
         if self.min is None:
-            self.min = events['t'][0]
+            self.min = events["t"][0]
         if self.max is None:
-            self.max = events['t'][-1]
-        return events[(events['t'] >= self.min) & (events['t'] <= self.max)]
+            self.max = events["t"][-1]
+        return events[(events["t"] >= self.min) & (events["t"] <= self.max)]
 
 
 @dataclass(frozen=True)
@@ -454,7 +454,7 @@ class ToAveragedTimesurface:
         temporal_window (float): how far back to look for past events for the time averaging
         tau (float): time constant to decay events around occuring event with.
         decay (str): can be either 'lin' or 'exp', corresponding to linear or exponential decay.
-        num_workers (int): number of workers to be deployed on the histograms computation. When >1, joblib is required. 
+        num_workers (int): number of workers to be deployed on the histograms computation. When >1, joblib is required.
     """
 
     sensor_size: Tuple[int, int, int]
@@ -574,13 +574,13 @@ class ToSparseTensor:
             include_incomplete=self.include_incomplete,
         )
         return torch.from_numpy(dense_frames).to_sparse()
-        
+
 
 @dataclass(frozen=True)
 class ToImage:
     """Counts up all events to a *single* image of size sensor_size. ToImage will typically
-    be used in combination with SlicedDataset to cut a recording into smaller chunks that 
-    are then individually binned to frames. 
+    be used in combination with SlicedDataset to cut a recording into smaller chunks that
+    are then individually binned to frames.
     """
 
     sensor_size: Tuple[int, int, int]
@@ -640,6 +640,35 @@ class ToVoxelGrid:
 
         return functional.to_voxel_grid_numpy(
             events.copy(), self.sensor_size, self.n_time_bins
+        )
+
+
+@dataclass(frozen=True)
+class ToBinaRep:
+    """Representation that takes T*B binary event frames to produce a sequence of T frames of N-bit numbers.
+    To do so, N binary frames are interpreted as a single frame of N-bit representation. Taken from the paper
+    Barchid et al. 2022, Bina-Rep Event Frames: a Simple and Effective Representation for Event-based cameras
+    https://arxiv.org/pdf/2202.13662.pdf
+    Parameters:
+        to_frame_transform (tonic.transforms.ToFrame): the ToFrame transform that creates the T*B binary event frames. Defaults to None.
+        n_frames (int): the number T of bina-rep frames.
+        n_bits (int): the number N of bits used in the N-bit representation.
+    """
+
+    to_frame_transform: Optional[ToFrame] = None
+    n_frames: Optional[int] = (1,)
+    n_bits: Optional[int] = (8,)
+
+    def __post_init__(self):
+        if self.to_frame_transform is None:
+            self.to_frame_transform = ToFrame(
+                None, n_time_bins=self.n_frames * self.n_bits
+            )
+
+    def __call__(self, events):
+
+        return functional.to_bina_rep_numpy(
+            events, self.to_frame_transform, self.n_frames, self.n_bits
         )
 
 

--- a/tonic/transforms.py
+++ b/tonic/transforms.py
@@ -643,32 +643,40 @@ class ToVoxelGrid:
         )
 
 
-@dataclass()
+@dataclass(frozen=True)
 class ToBinaRep:
     """Representation that takes T*B binary event frames to produce a sequence of T frames of N-bit numbers.
     To do so, N binary frames are interpreted as a single frame of N-bit representation. Taken from the paper
     Barchid et al. 2022, Bina-Rep Event Frames: a Simple and Effective Representation for Event-based cameras
     https://arxiv.org/pdf/2202.13662.pdf
+
     Parameters:
-        to_frame_transform (tonic.transforms.ToFrame): the ToFrame transform that creates the T*B binary event frames. Defaults to None.
         n_frames (int): the number T of bina-rep frames.
         n_bits (int): the number N of bits used in the N-bit representation.
+
+
+    Example:
+        >>> n_time_bins = n_frames * n_bits
+        >>>
+        >>> transforms.Compose([
+        >>>     transforms.ToFrame(
+        >>>         sensor_size=sensor_size,
+        >>>         n_time_bins=n_time_bins,
+        >>>     ),
+        >>>     transforms.ToBinaRep(
+        >>>         n_frames=n_frames,
+        >>>         n_bits=n_bits,
+        >>>     ),
+        >>> ])
     """
 
     n_frames: Optional[int] = 1
     n_bits: Optional[int] = 8
-    to_frame_transform: Optional[ToFrame] = None
 
-    def __post_init__(self):
-        if self.to_frame_transform is None:
-            self.to_frame_transform = ToFrame(
-                None, n_time_bins=self.n_frames * self.n_bits
-            )
-
-    def __call__(self, events):
+    def __call__(self, event_frames):
 
         return functional.to_bina_rep_numpy(
-            events, self.to_frame_transform, self.n_frames, self.n_bits
+            event_frames, self.n_frames, self.n_bits
         )
 
 


### PR DESCRIPTION
Hello,

I have added a new event representation: Bina-Rep, from the paper ([Bina-Rep Event Frames: a Simple and Effective Representation for Event-based cameras](https://arxiv.org/abs/2202.13662) . The paper is accepted at [ICIP 2022, in the special session dedicated to neuromorphic image acquisition & analysis](https://2022.ieeeicip.org/special-sessions/#) 

Briefly explained, it is a sort of "post-processing" method after running a `ToFrame()` representation. Let's say you obtain `T*N` binary frames after a `ToFrame()` transform. Bina-Rep decomposes this sequence of frames into `T` frames of `N-bit` numbers (which are named "bina-rep" frames). The advantage of bina-rep frames is to have an event representation that contains:
1. The presence of an event (*similar to simple frame representation*)
2. The number of accumulated events (*similar to event frame representation*)
3. The order of arrival of these events in the original `N` binary frames that are used to produce the bina-rep frame

I want to draw your attention about one trick I implemented for easier use. The transform dataclass (in `tonic/transforms.py`) is not frozen like the others. I removed this flag to implement a `__post_init__()` function that creates a default `ToFrame` transform used in the bina-rep code. As I don't know your requirements (and I'm afraid I am not an experienced Open-Source contributor), I wanted to know if this is ok for you.

Thanks for your hard work!