### PR TITLE
Added and (partially) tested STMNIST using datapipes.

### DIFF
--- a/tonic/prototype/datasets/stmnist.py
+++ b/tonic/prototype/datasets/stmnist.py
@@ -1,0 +1,97 @@
+from torchdata.datapipes.iter import (
+    FileLister,
+    Filter,
+    Forker,
+    Zipper,
+)
+from scipy.io import loadmat
+import numpy as np
+from pathlib import Path
+from tonic.download_utils import extract_archive, check_integrity
+
+#####
+# Dataset properties.
+#####
+
+sensor_size = (10, 10, 2)
+dtype = np.dtype([("x", int), ("y", int), ("t", int), ("p", int)])
+# The authors want you to compile a form for the dataset download. Hence, 
+# the user has to manually download the archive and provide the path to it. 
+# Our code will manage the archive extraction.
+
+#####
+# Functions
+#####
+
+
+def is_mat_file(filename):
+    return filename.endswith("mat") and "LUT" not in filename
+
+
+def read_label_from_filepath(filepath):
+    return int(filepath.split("/")[-2])
+
+
+def at_least_n_files(root, n_files, file_type):
+    check = n_files <= len(list(Path(root).glob(f"**/*{file_type}")))
+    return check
+
+
+def spiketrain_to_array(matfile):
+    # Transposing since the order is (address, event),
+    # but we like (event, address).
+    mat = loadmat(matfile)
+    spiketrain = mat["spiketrain"].T
+    # Separating coordinates and timestamps.
+    spikes, timestamps = spiketrain[:, :-1], spiketrain[:, -1]
+    # Getting events addresses.
+    # First entry -> Event number.
+    # Second entry -> Event address in [0,100).
+    events_nums, events_addrs = spikes.nonzero()
+    # Mapping addresses to 2D coordinates.
+    # The mapping is (x%address, y//address), from the paper.
+    events = np.zeros((len(events_nums)), dtype=dtype)
+    events["x"] = events_addrs % sensor_size[0]
+    events["y"] = events_addrs // sensor_size[1]
+    # Converting floating point seconds to integer microseconds.
+    events["t"] = (timestamps[events_nums] * 1e6).astype(int)
+    # Converting -1 polarities to 0.
+    events["p"] = np.max(spikes[(events_nums, events_addrs)], 0).astype(int)
+    return events
+
+
+def check_exists(filepath):
+    check = False
+    check = check_integrity(filepath)
+    check = at_least_n_files(filepath, n_files=100, file_type=".mat")
+    return check
+
+
+#####
+# Dataset
+#####
+
+
+def stmnist(root, transform=None, target_transform=None):
+    # Setting file path depending on train value.
+    # The root is specified like "directory/archive.zip". 
+    # We strip 'archive.zip' and get only 'directory', and 
+    # we append 'data_submission' to it.
+    filepath = root[::-1].split("/", 1)[-1][::-1] + "/data_submission"
+    # Extracting the ZIP archive.
+    if not check_exists(filepath):
+        extract_archive(root)
+    # Creating the datapipe.
+    dp = FileLister(root=filepath, recursive=True)
+    dp = Filter(dp, is_mat_file)
+    # Thinking about avoiding this fork in order to apply transform to both target and events.
+    # However, we need it for NMNIST to select the first saccade.
+    event_dp, label_dp = Forker(dp, num_instances=2)
+    event_dp = event_dp.map(spiketrain_to_array)
+    label_dp = label_dp.map(read_label_from_filepath)
+    if transform:
+        event_dp = event_dp.map(transform)
+    if target_transform:
+        label_dp = label_dp.map(target_transform)
+    dp = Zipper(event_dp, label_dp)
+    return dp


### PR DESCRIPTION
I added STMNIST (#210) using the datapipe approach (just for fun), in the `prototype` section. This is a _lazy commit_, just like NMNIST.

The authors want you to fill a form every time you download the dataset; hence, the code manages only the archive extraction and management. The user downloads the archive and provides the path to it.

The sensor is a 10x10 array, but the data is provided with an address in the `[0,100)` range (actually, in `[1,100]`, thanks Matlab for starting from 1 with indices).
![image](https://user-images.githubusercontent.com/45739782/185696194-21a52ee9-0786-4651-9e4a-54ee7a7e0180.png)
![image](https://user-images.githubusercontent.com/45739782/185696554-d7b475ca-3bc6-48f0-8fe1-f29cc506d0b2.png)
Given the address `addr`, I obtain the coordinates as:
```python
x, y = addr%10, addr//10 # Addresses start from 0 and not 1.
```
Does it sound correct when looking at their lookup table?
Moreover, their timestamps are floating points way beyond microsecond resolution, and some events entries have two pixels activated at once. I managed this by decomposing the events in two separated ones with the same timestamp and different coordinates. Here's a sample with two events:
![image](https://user-images.githubusercontent.com/45739782/185696948-0a78b2e7-f2a6-4c1e-b94a-fdbcecf2dc55.png)

The authors provide data in the MAT format. However, these are not HDF5 files, since they use an old Matlab version and, hence, I was not able to use `h5py` for the array management and I have relied on `scipy.io.loadmat`. Any suggestions about this? May it be a problem?