### PR TITLE
Fix two bugs in DSEC class

### DIFF
--- a/tonic/datasets/dsec.py
+++ b/tonic/datasets/dsec.py
@@ -254,8 +254,8 @@ class DSEC(Dataset):
                     data["t"] += file["t_offset"][()]
 
             elif "images" in data_name:
-                images_rectified_filenames = list_files(
-                    full_base_folder, ".png", prefix=True
+                images_rectified_filenames = sorted(
+                    list_files(full_base_folder, ".png", prefix=True)
                 )
                 data = np.stack(
                     [np.array(Image.open(file)) for file in images_rectified_filenames]
@@ -276,7 +276,7 @@ class DSEC(Dataset):
                 "disparity_event",
                 "disparity_image",
             ]:
-                png_filenames = list_files(full_base_folder, ".png", prefix=True)
+                png_filenames = sorted(list_files(full_base_folder, ".png", prefix=True))
                 target = np.stack(
                     [np.array(Image.open(file)) for file in png_filenames]
                 )
@@ -285,7 +285,7 @@ class DSEC(Dataset):
                 "optical_flow_forward_event",
                 "optical_flow_backward_event",
             ]:
-                png_filenames = list_files(full_base_folder, ".png", prefix=True)
+                png_filenames = sorted(list_files(full_base_folder, ".png", prefix=True))
                 target = np.array(
                     [imageio.imread(file, format="PNG-FI") for file in png_filenames]
                 ).astype(float)

--- a/tonic/datasets/dsec.py
+++ b/tonic/datasets/dsec.py
@@ -289,7 +289,7 @@ class DSEC(Dataset):
                 target = np.array(
                     [imageio.imread(file, format="PNG-FI") for file in png_filenames]
                 ).astype(float)
-                target[:, :, :, :2] -= 2 ^ 15
+                target[:, :, :, :2] -= 2 ** 15
                 target[:, :, :, :2] /= 128
 
             elif target_name == "disparity_timestamps":


### PR DESCRIPTION
This MR fixes two bugs in the DSEC class (`tonic/datasets/dsec.py`). Both are related to optic flow ground truth:

1. After loading optic flow ground truth from the PNG files, `2 ** 15` is subtracted (previously: `2 ^ 15` which evaluates to 2 XOR 15 = 13).
2. The files are now loaded in order of their filenames (previously: random order).