### PR TITLE
Make sure looping over DiscCachedDataset terminates correctly

### DIFF
--- a/test/test_caching.py
+++ b/test/test_caching.py
@@ -92,3 +92,8 @@ def test_caching_from_files():
     dataset = DiskCachedDataset(dataset=None, cache_path=cache_path)
     assert len(dataset) == n_cached_samples
     assert len(os.listdir(cache_path)) == len(dataset)
+    
+    # Make sure iteration stops properly when available number of items is reached.
+    for item in dataset:
+        events, target = item
+

--- a/tonic/cached_dataset.py
+++ b/tonic/cached_dataset.py
@@ -129,6 +129,9 @@ class DiskCachedDataset:
             self.n_samples = len(self.dataset)
 
     def __getitem__(self, item) -> Tuple[object, object]:
+        if self.dataset is None and item >= self.n_samples:
+            raise IndexError(f"This dataset only has {self.n_samples} items.")
+
         copy = np.random.randint(self.num_copies)
         file_path = os.path.join(self.cache_path, f"{item}_{copy}.hdf5")
         try:
@@ -138,6 +141,8 @@ class DiskCachedDataset:
                 f"Data {item}: {file_path} not in cache, generating it now",
                 stacklevel=2,
             )
+
+
             data, targets = self.dataset[item]
             save_to_disk_cache(
                 data, targets, file_path=file_path, compression=self.compression


### PR DESCRIPTION
`DiskCachedDataset` can be instantiated with `dataset=None`, to load from cache exclusively.
This is a great feature. However, when looping over the dataset, it runs into troubles. 
```
for item in cached_dataset:
    ...
```
will terminate in a `TypeError`. The reason is that as soon as the loop queries an item beyond the size of the cached dataset, the getitem method tries to access `self.dataset[item]`. Because `self.dataset` is `None`, this fails.
Normally a dataset would raise an `IndexError` in such a case, which causes the for loop to stop iteration without any error.

This MR introduces the same behavior for `DiskCachedDataset`, i.e. when an item is queried that is beyond the length of the dataset, it will throw an `IndexError`, allowing safely iterating over it. I also added a unit test to make sure this works.