### PR TITLE
Exposed the extra/speaker property in the SHD dataset 

### DIFF
--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -136,11 +136,12 @@ def create_hsd_data(filename, n_samples):
         times = np.random.random(size=(n_samples, 100)).astype(np.float16)
         units = (np.random.random(size=(n_samples, 100)) * 700).astype(np.uint16)
         keys = ["zero", "one"]
+        speaker= (np.random.random(size=n_samples) * 20).astype(np.uint16)
         write_file.create_dataset("spikes/units", data=units)
         write_file.create_dataset("spikes/times", data=times)
         write_file.create_dataset("labels", data=[1] * n_samples)
         write_file.create_dataset("extra/keys", data=keys)
-
+        write_file.create_dataset("extra/speaker", data= speaker)
 
 class SHDTestCaseTrain(dataset_utils.DatasetTestCase):
     DATASET_CLASS = datasets.SHD

--- a/tonic/datasets/hsd.py
+++ b/tonic/datasets/hsd.py
@@ -100,7 +100,11 @@ class SHD(HSD):
 
         file = h5py.File(os.path.join(self.location_on_system, self.data_filename), "r")
         self.classes = file["extra/keys"][()]
+        self._speakers = file["extra/speaker"][()]
 
+    @property
+    def speakers(self):
+        return self._speakers[()]
 
 class SSC(HSD):
     """`Spiking Speech Commands <https://zenkelab.org/resources/spiking-heidelberg-datasets-shd/>`_

--- a/tonic/datasets/hsd.py
+++ b/tonic/datasets/hsd.py
@@ -100,11 +100,11 @@ class SHD(HSD):
 
         file = h5py.File(os.path.join(self.location_on_system, self.data_filename), "r")
         self.classes = file["extra/keys"][()]
-        self._speakers = file["extra/speaker"][()]
+        self._speaker = file["extra/speaker"][()]
 
     @property
-    def speakers(self):
-        return self._speakers[()]
+    def speaker(self):
+        return self._speaker[()]
 
 class SSC(HSD):
     """`Spiking Speech Commands <https://zenkelab.org/resources/spiking-heidelberg-datasets-shd/>`_


### PR DESCRIPTION
For the Spiking Heidelberg Digits dataset, it can be useful to run a cross-validation along folds where one speaker is left out. In order to do so, we need the speaker information stored in the extra/speaker field of the SHD hdf5 files.
This pull request aims to expose this information to users of tonic's shd dataset if they wish to do so.
@neworderofjamie and I thought that doing it with the property "speakers" rather than adding to the standard data format was the right approach and should only create extra unpacking of data when this information is actually accessed by a user.