### PR TITLE
Change time surface implementation to get time surfaces at intervals

### DIFF
--- a/test/test_representations.py
+++ b/test/test_representations.py
@@ -201,18 +201,23 @@ def test_representation_image():
 
 
 @pytest.mark.parametrize(
-    "surface_dimensions, tau,", [((15, 15), 100), ((3, 3), 10), (None, 1e4)]
+    "surface_dimensions, tau, delta_t", [((15, 15), 100, 0), ((3, 3), 10, 1e4), (None, 1e4, 1e5)]
 )
-def test_representation_time_surface(surface_dimensions, tau):
+def test_representation_time_surface(surface_dimensions, tau, delta_t):
     orig_events, sensor_size = create_random_input(n_events=1000)
 
     transform = transforms.ToTimesurface(
-        sensor_size=sensor_size, surface_dimensions=surface_dimensions, tau=tau
+        sensor_size=sensor_size, surface_dimensions=surface_dimensions, tau=tau, delta_t=delta_t
     )
 
     surfaces = transform(orig_events)
 
-    assert surfaces.shape[0] == len(orig_events)
+    if delta_t == 0:
+        assert surfaces.shape[0] == len(orig_events)
+    else:
+        duration = orig_events["t"][-1] - orig_events["t"][0]
+        assert surfaces.shape[0] == duration // delta_t 
+        
     assert surfaces.shape[1] == 2
     if surface_dimensions:
         assert surfaces.shape[2:] == surface_dimensions

--- a/tonic/functional/to_timesurface.py
+++ b/tonic/functional/to_timesurface.py
@@ -75,11 +75,9 @@ def to_timesurface_numpy(
         if delta_t == 0:
             all_surfaces[index, :, :, :] = timesurface
         else:
-            print(float(last_event_timestamp) - float(last_accumulated))
             last_event_timestamp = event['t']
             if float(last_event_timestamp) - float(last_accumulated) > delta_t:
                 all_surfaces[accumulated_surface_index, :, :, :] = timesurface 
                 accumulated_surface_index += 1
                 last_accumulated = event['t']
-                print(accumulated_surface_index)
     return all_surfaces

--- a/tonic/functional/to_timesurface.py
+++ b/tonic/functional/to_timesurface.py
@@ -2,7 +2,7 @@ import numpy as np
 
 
 def to_timesurface_numpy(
-    events, sensor_size, surface_dimensions=None, tau=5e3, decay="lin"
+    events, sensor_size, surface_dimensions=None, tau=5e3, delta_t=0, decay="lin"
 ):
     """Representation that creates timesurfaces for each event in the recording. Modeled after the
     paper Lagorce et al. 2016, Hots: a hierarchy of event-based time-surfaces for pattern
@@ -12,12 +12,25 @@ def to_timesurface_numpy(
         surface_dimensions (int, int): width does not have to be equal to height, however both numbers have to be odd.
             if surface_dimensions is None: the time surface is defined globally, on the whole sensor grid.
         tau (float): time constant to decay events around occuring event with.
+        delta_t (float): the interval at which the time-surfaces are accumulated, if set 0 number of time-surfaces will
+            equal to the number of events. (defaults to 0)
         decay (str): can be either 'lin' or 'exp', corresponding to linear or exponential decay.
 
     Returns:
-        array of timesurfaces with dimensions (w,h) or (p,w,h)
+        array of timesurfaces with dimensions (n_events//delta_t,w,h) or (n_events//delta_t,p,w,h)
     """
 
+    assert delta_t >= 0, print("Parameter delta_t cannot be negative.")
+
+    if delta_t > 0:
+        duration = events['t'][-1] - events['t'][0]
+        n_surfaces = int(duration // delta_t)
+        last_accumulated = events['t'][0]
+        last_event_timestamp = events['t'][0]
+        accumulated_surface_index = 0
+    else:
+        n_surfaces = len(events)
+    
     if surface_dimensions:
         assert len(surface_dimensions) == 2
         assert surface_dimensions[0] % 2 == 1 and surface_dimensions[1] % 2 == 1
@@ -35,9 +48,11 @@ def to_timesurface_numpy(
     )
     timestamp_memory -= tau * 3 + 1
     all_surfaces = np.zeros(
-        (len(events), sensor_size[2], surface_dimensions[1], surface_dimensions[0])
+        (n_surfaces, sensor_size[2], surface_dimensions[1], surface_dimensions[0])
     )
+
     for index, event in enumerate(events):
+        
         x = int(event["x"])
         y = int(event["y"])
         timestamp_memory[int(event["p"]), y + radius_y, x + radius_x] = event["t"]
@@ -56,5 +71,15 @@ def to_timesurface_numpy(
             timesurface[timesurface < 0] = 0
         elif decay == "exp":
             timesurface = np.exp(timestamp_context / tau)
-        all_surfaces[index, :, :, :] = timesurface
+         
+        if delta_t == 0:
+            all_surfaces[index, :, :, :] = timesurface
+        else:
+            print(float(last_event_timestamp) - float(last_accumulated))
+            last_event_timestamp = event['t']
+            if float(last_event_timestamp) - float(last_accumulated) > delta_t:
+                all_surfaces[accumulated_surface_index, :, :, :] = timesurface 
+                accumulated_surface_index += 1
+                last_accumulated = event['t']
+                print(accumulated_surface_index)
     return all_surfaces

--- a/tonic/transforms.py
+++ b/tonic/transforms.py
@@ -916,12 +916,15 @@ class ToTimesurface:
         surface_dimensions (int, int): width does not have to be equal to height, however both numbers have to be odd.
             if surface_dimensions is None: the time surface is defined globally, on the whole sensor grid.
         tau (float): time constant to decay events around occuring event with.
+        delta_t (float): the interval at which the time-surfaces are accumulated, if set 0 number of time-surfaces will
+            equal to the number of events. (defaults to 0.0) 
         decay (str): can be either 'lin' or 'exp', corresponding to linear or exponential decay.
     """
 
     sensor_size: Tuple[int, int, int]
     surface_dimensions: Union[None, Tuple[int, int]] = None
     tau: float = 5e3
+    delta_t: float = 0.0
     decay: str = "lin"
 
     def __call__(self, events):
@@ -931,6 +934,7 @@ class ToTimesurface:
             sensor_size=self.sensor_size,
             surface_dimensions=self.surface_dimensions,
             tau=self.tau,
+            delta_t=self.delta_t,
             decay=self.decay,
         )
 


### PR DESCRIPTION
I have added a parameter called `delta_t`, and the transform returns surfaces only at `delta_t` intervals as we discussed.