### PR TITLE
added extract function for DAVIS346 recorded aedat files

### DIFF
--- a/tonic/io.py
+++ b/tonic/io.py
@@ -143,6 +143,33 @@ def read_dvs_red(filename):
     return shape, xytp
 
 
+def read_davis_346(filename):
+    """Get the aer events from DAVIS346 with resolution of (260, 346)
+
+    Parameters:
+        filename:   filename
+
+    Returns:
+        shape (tuple):
+            (height, width) of the sensor array
+
+        events: numpy structured array of events
+    """
+    data_version, data_start = read_aedat_header_from_file(filename)
+    all_events = get_aer_events_from_file(filename, data_version, data_start)
+    all_addr = all_events["address"]
+    t = all_events["timeStamp"]
+
+    # x, y, and p : bit-shift and bit-mask values taken from jAER (https://github.com/SensorsINI/jaer)
+    x = (346 - 1) - ((all_addr & 4190208) >> 12)
+    y = (260 - 1) - ((all_addr & 2143289344) >> 22)
+    p = ((all_addr & 2048) >> 11)
+
+    xytp = make_structured_array(x, y, t, p)
+    shape = (346, 260)
+    return shape, xytp
+
+
 def read_dvs_346mini(filename):
     """Get the aer events from DVS with resolution of (132,104)
 


### PR DESCRIPTION
I used this function to read event recordings as aedat files from DAVIS346 sensor of 346x260 resolution. I tried the existing read_dvs_red() method but noticed that the (x,y) pixel locations were beyond the resolution itself:
![Screenshot from 2023-09-01 11-07-06](https://github.com/neuromorphs/tonic/assets/14059534/2edfc30f-45af-4117-8cfa-cc04ad0ec288)
The bit mask and bit shift values used in the read_davis_346() method are taken from jAER (https://github.com/SensorsINI/jaer). jAER was used to record events into the aedat file too. The pixel locations look fine when reading from this function. I've also attached an event frame reconstructed from the events read from aedat recordings using the read_davis_346() method.
![Screenshot from 2023-09-01 11-06-58](https://github.com/neuromorphs/tonic/assets/14059534/6294ec5c-395a-4cb6-9b92-2a6e29d13008)
![002 772](https://github.com/neuromorphs/tonic/assets/14059534/fde03f4b-82d9-4c03-a0e2-f4285da2cb5f)
