### PR TITLE
Revert bugfix

### DIFF
--- a/tonic/functional/event_downsampling.py
+++ b/tonic/functional/event_downsampling.py
@@ -46,8 +46,8 @@ def differentiator_downsample(events: np.ndarray, sensor_size: tuple, target_siz
         time = int(differentiated_time // dt)
         
         # Separate events based on polarity and apply Heaviside
-        event_hist_pos = (np.maximum(event_histogram >= noise_threshold, 0)).clip(max=1)
-        event_hist_neg = (-np.minimum(-event_histogram >= noise_threshold, 0)).clip(max=1)
+        event_hist_pos = event_histogram >= noise_threshold
+        event_hist_neg = -event_histogram >= noise_threshold
         
         frame_histogram[time,...,1] += event_hist_pos
         frame_histogram[time,...,0] += event_hist_neg


### PR DESCRIPTION
Bugfix didn't take into account that min(True, 0) is 0, so there are no negative events