### PR TITLE
Fix dataset downloads: use the figshare API endpoint (WAF blocks ndownloader)

### DIFF
--- a/tonic/datasets/cifar10dvs.py
+++ b/tonic/datasets/cifar10dvs.py
@@ -30,7 +30,7 @@ class CIFAR10DVS(Dataset):
                                          labels at the same time.
     """
 
-    url = "https://figshare.com/ndownloader/files/38023437"
+    url = "https://api.figshare.com/v2/file/download/38023437"
 
     filename = "CIFAR10DVS.zip"
     file_md5 = "ce3a4a0682dc0943703bd8f749a7701c"

--- a/tonic/datasets/dvsgesture.py
+++ b/tonic/datasets/dvsgesture.py
@@ -32,8 +32,8 @@ class DVSGesture(Dataset):
                                          labels at the same time.
     """
 
-    test_url = "https://figshare.com/ndownloader/files/38020584"
-    train_url = "https://figshare.com/ndownloader/files/38022171"
+    test_url = "https://api.figshare.com/v2/file/download/38020584"
+    train_url = "https://api.figshare.com/v2/file/download/38022171"
     test_md5 = "56070e45dadaa85fff82e0fbfbc06de5"
     train_md5 = "3a8f0d4120a166bac7591f77409cb105"
     test_filename = "ibmGestureTest.tar.gz"


### PR DESCRIPTION
Fixes #329, fixes #330.

## What broke

`figshare.com/ndownloader/files/<id>` now sits behind an AWS WAF bot challenge. Non-browser clients get an empty `HTTP 202` with `x-amzn-waf-action: challenge` instead of the file, so tonic's downloader writes a 0-byte archive (`0it [00:00, ?it/s]` in the reports) and extraction fails. A browser user agent does not help; the challenge is not UA-based.

## The fix

`https://api.figshare.com/v2/file/download/<id>` serves the same files (same ids) without the challenge, redirecting straight to S3. This PR swaps the three affected URLs (DVSGesture train/test, CIFAR10DVS); the md5s are unchanged.

## Verification

- `curl -sI https://figshare.com/ndownloader/files/38022171` → `202`, `x-amzn-waf-action: challenge`, 0 bytes
- Full download of the DVSGesture test archive (691 MB) through the API endpoint completes and matches the expected md5 `56070e45dadaa85fff82e0fbfbc06de5`
- CIFAR10DVS and DVSGesture-train respond to range requests through the API endpoint with the correct total sizes (11.2 GB / 2.4 GB); I did not re-download those in full, their md5s in the dataset classes are untouched